### PR TITLE
AKSEP: clarify preview server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run the AKSEP preview server from the repository root:
 npm run AKSEP
 ```
 
-This installs dependencies inside `projects/AKSEP/src` and starts Eleventy in serve mode so you can view the site at `http://localhost:8080` (default). The generated files appear directly in `projects/AKSEP`.
+The command installs dependencies and starts Eleventy from the `projects/AKSEP` directory. The `src` folder merely holds the deployable files that Eleventy processes. You can view the site at `http://localhost:8080` (default). The generated files appear directly in `projects/AKSEP`.
 
 ### Ausblick
 


### PR DESCRIPTION
## Summary
- clarify that `npm run AKSEP` installs dependencies and serves from `projects/AKSEP`
- explain that `src` only contains deployable Eleventy files

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*
- `cd projects/AKSEP && npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68863aa42cf48333adb82005457c40be