### PR TITLE
AKSEP: clean planning notes

### DIFF
--- a/projects/AKSEP/AGENTS.md
+++ b/projects/AKSEP/AGENTS.md
@@ -29,6 +29,8 @@ AKSEP/de/Begriffe/<begriff>/index.html
 AKSEP\projects\AKSEP\local-Tree.txt
 WICHTIG: Diese Datei wird durch einen PowerShell-Befehl erzeugt; sie kann zwar zur temporären Dokumentation von Änderungen an der Dateistruktur verwendet werden, wird aber regelmäßig mit dem Status quo überschrieben.
 
+Zusätzlich fasst `Planung.md` die bisherigen technischen Diskussionen zusammen und dient bei Fragen zur Webseiten-Struktur oder weiterführenden Planungen als Referenz.
+
 ---
 
 ### 2. Parteiprogrammstruktur

--- a/projects/AKSEP/Planung.md
+++ b/projects/AKSEP/Planung.md
@@ -9,101 +9,92 @@ Gibt es welche, die positiv herausstechen und/oder speziell für unser Vorhaben 
 </prompt1>
 
 <antwort1>
-<div class="p-0! px-4 text-sm leading-5 markdown prose dark:prose-invert w-full break-words dark markdown-new-styling"><p data-start="0" data-end="419">Ja, der Einsatz eines Frameworks für die Entwicklung einer Webseite ist in den meisten Fällen sinnvoll. Frameworks übernehmen viele Standardaufgaben (Routing, Vorlagen, State-Management, Build-Prozess etc.) und ermöglichen es, schneller, strukturierter und wartbarer zu entwickeln. Welche Lösung sich am besten eignet, hängt aber stark vom geplanten Funktionsumfang, dem technischen Umfeld und euren Teampräferenzen ab.</p>
-<p data-start="421" data-end="476"><strong data-start="421" data-end="474">Front‑End Frameworks (Client-seitige Entwicklung)</strong></p>
-<ul data-start="477" data-end="1156">
-<li data-start="477" data-end="689">
-<p data-start="479" data-end="689"><strong data-start="479" data-end="488">React</strong> – Marktführer mit einem sehr großen Ökosystem; flexibel, aber etwas konfigurationsintensiv. Ideal, wenn ihr viel Individualisierung braucht und bereit seid, viele Bibliotheken selbst zu kombinieren.</p>
-</li>
-<li data-start="690" data-end="849">
-<p data-start="692" data-end="849"><strong data-start="692" data-end="702">Vue.js</strong> – leichter Einstieg, klare Struktur, gute Mischung aus Flexibilität und Voreinstellungen. Sinnvoll, wenn das Team schnell produktiv werden soll.</p>
-</li>
-<li data-start="850" data-end="1004">
-<p data-start="852" data-end="1004"><strong data-start="852" data-end="863">Angular</strong> – sehr umfassend und strikt strukturiert; eignet sich gut für größere Projekte mit vielen Entwicklern, da es klare Best Practices vorgibt.</p>
-</li>
-<li data-start="1005" data-end="1156">
-<p data-start="1007" data-end="1156"><strong data-start="1007" data-end="1017">Svelte</strong> – kompakt und performancestark, mit Compiler-basiertem Ansatz. Interessant, wenn ihr minimalistische Bundles und hohe Performance braucht.</p>
-</li>
-</ul>
-<p data-start="1158" data-end="1217"><strong data-start="1158" data-end="1215">Full-Stack/SSR Frameworks (Server-seitig oder Hybrid)</strong></p>
-<ul data-start="1218" data-end="1803">
-<li data-start="1218" data-end="1389">
-<p data-start="1220" data-end="1389"><strong data-start="1220" data-end="1231">Next.js</strong> (für React) – kombiniert Server-Side Rendering (SSR), statische Generierung und API-Routen. Sehr beliebt für performante, SEO-freundliche Seiten mit React.</p>
-</li>
-<li data-start="1390" data-end="1503">
-<p data-start="1392" data-end="1503"><strong data-start="1392" data-end="1403">Nuxt.js</strong> (für Vue) – analog zu Next.js, aber für Vue. Bietet SSR und statische Generierung out of the box.</p>
-</li>
-<li data-start="1504" data-end="1626">
-<p data-start="1506" data-end="1626"><strong data-start="1506" data-end="1519">SvelteKit</strong> – vergleichbar mit Next/Nuxt, aber für Svelte. Noch nicht so etabliert, aber sehr modern und performant.</p>
-</li>
-<li data-start="1627" data-end="1803">
-<p data-start="1629" data-end="1803"><strong data-start="1629" data-end="1639">Gatsby</strong> – baut auf React auf und richtet sich besonders an statische Seiten (JAMstack). Gut für Content-driven Seiten, aber kann bei dynamischen Features komplexer werden.</p>
-</li>
-</ul>
-<p data-start="1805" data-end="1846"><strong data-start="1805" data-end="1844">Back-End Frameworks (Server-seitig)</strong></p>
-<ul data-start="1847" data-end="2536">
-<li data-start="1847" data-end="1961">
-<p data-start="1849" data-end="1961"><strong data-start="1849" data-end="1860">Express</strong> (Node.js) – minimalistisch, flexibel, ideal für REST-APIs oder als Basis für eigene Architekturen.</p>
-</li>
-<li data-start="1962" data-end="2088">
-<p data-start="1964" data-end="2088"><strong data-start="1964" data-end="1974">NestJS</strong> – baut auf Express/Fastify auf, strukturiert wie Angular; eignet sich für größere TypeScript-basierte Projekte.</p>
-</li>
-<li data-start="2089" data-end="2287">
-<p data-start="2091" data-end="2287"><strong data-start="2091" data-end="2101">Django</strong> (Python) – sehr ausgereift, enthält viele Funktionen (ORM, Admin-Interface, Authentifizierung). Besonders geeignet, wenn ihr Python bevorzugt und schnell ein robustes Backend möchtet.</p>
-</li>
-<li data-start="2288" data-end="2423">
-<p data-start="2290" data-end="2423"><strong data-start="2290" data-end="2307">Ruby on Rails</strong> – “Convention over Configuration”; schneller Einstieg und produktive Entwicklung für datengetriebene Anwendungen.</p>
-</li>
-<li data-start="2424" data-end="2536">
-<p data-start="2426" data-end="2536"><strong data-start="2426" data-end="2437">Laravel</strong> (PHP) – moderner PHP-Framework-Klassiker; besonders gut, wenn bereits PHP-Erfahrung vorhanden ist.</p>
-</li>
-</ul>
-<p data-start="2538" data-end="2572"><strong data-start="2538" data-end="2570">Static Site Generators / CMS</strong></p>
-<ul data-start="2573" data-end="2946">
-<li data-start="2573" data-end="2713">
-<p data-start="2575" data-end="2713"><strong data-start="2575" data-end="2583">Hugo</strong> und <strong data-start="2588" data-end="2598">Jekyll</strong> – sehr beliebt für reine Content-Seiten oder Dokumentation, wenn keine umfangreiche Backend-Logik benötigt wird.</p>
-</li>
-<li data-start="2714" data-end="2848">
-<p data-start="2716" data-end="2848"><strong data-start="2716" data-end="2726">Strapi</strong> (Headless CMS) – wenn ihr ein flexibles Backend mit UI für Content-Editoren braucht und das Frontend frei wählen wollt.</p>
-</li>
-<li data-start="2849" data-end="2946">
-<p data-start="2851" data-end="2946"><strong data-start="2851" data-end="2865">Contentful</strong>, <strong data-start="2867" data-end="2877">Sanity</strong>, <strong data-start="2879" data-end="2891">Directus</strong> – vergleichbare Headless-CMS-Lösungen, teils als SaaS.</p>
-</li>
-</ul>
-<hr data-start="2948" data-end="2951">
-<p data-start="2953" data-end="2989"><strong data-start="2953" data-end="2987">Was positiv herausstechen kann</strong></p>
-<ul data-start="2990" data-end="3597">
-<li data-start="2990" data-end="3129">
-<p data-start="2992" data-end="3129"><strong data-start="2992" data-end="3015">Next.js und Nuxt.js</strong> sind derzeit sehr beliebt, weil sie die Vorteile von Client- und Server-Seite verbinden und für SEO stark sind.</p>
-</li>
-<li data-start="3130" data-end="3249">
-<p data-start="3132" data-end="3249"><strong data-start="3132" data-end="3142">Django</strong> oder <strong data-start="3148" data-end="3159">Laravel</strong> glänzen, wenn ihr schnell ein komplettes Backend mit vielen Standardfunktionen braucht.</p>
-</li>
-<li data-start="3250" data-end="3402">
-<p data-start="3252" data-end="3402"><strong data-start="3252" data-end="3265">SvelteKit</strong> und <strong data-start="3270" data-end="3280">Svelte</strong> werden oft für Performance und einfache Syntax gelobt, sofern ihr mit ihrem noch relativ jungen Ökosystem zurechtkommt.</p>
-</li>
-<li data-start="3403" data-end="3597">
-<p data-start="3405" data-end="3597"><strong data-start="3405" data-end="3421">Headless CMS</strong> (Strapi/Contentful/etc.) sind besonders attraktiv, wenn Redakteure Inhalte pflegen sollen, ohne die Entwickler zu belasten, und wenn ihr Frontend und Backend entkoppeln wollt.</p>
-</li>
-</ul>
-<hr data-start="3599" data-end="3602">
-<p data-start="3604" data-end="3711"><strong data-start="3604" data-end="3641">Nächste Schritte / Klärungsfragen</strong><br data-start="3641" data-end="3644">
-Um passgenaue Empfehlungen zu geben, wäre es hilfreich zu wissen:</p>
-<ol data-start="3712" data-end="4125">
-<li data-start="3712" data-end="3819">
-<p data-start="3715" data-end="3819">Welche Art von Webseite plant ihr? (z. B. Unternehmenspräsenz, E-Commerce-Shop, interaktive App, Blog)</p>
-</li>
-<li data-start="3820" data-end="3911">
-<p data-start="3823" data-end="3911">Gibt es Präferenzen bei der Programmiersprache oder bereits vorhandene Skills im Team?</p>
-</li>
-<li data-start="3912" data-end="4036">
-<p data-start="3915" data-end="4036">Welche Prioritäten sind euch wichtig? (SEO, Performance, schnelle Entwicklung, Skalierbarkeit, Kosten, Wartungsaufwand)</p>
-</li>
-<li data-start="4037" data-end="4125">
-<p data-start="4040" data-end="4125">Wie viel Content soll durch Nicht-Entwickler (Redakteure, Marketing) gepflegt werden?</p>
-</li>
-</ol>
-<p data-start="4127" data-end="4238" data-is-last-node="" data-is-only-node="">Mit diesen Informationen kann ich euch gezielter weiterhelfen und konkrete Framework-Kombinationen vorschlagen.</p></div>
+Ja, der Einsatz eines Frameworks für die Entwicklung einer Webseite ist in den meisten Fällen sinnvoll. Frameworks übernehmen viele Standardaufgaben (Routing, Vorlagen, State-Management, Build-Prozess etc.) und ermöglichen es, schneller, strukturierter und wartbarer zu entwickeln. Welche Lösung sich am besten eignet, hängt aber stark vom geplanten Funktionsumfang, dem technischen Umfeld und euren Teampräferenzen ab.
+
+**Front‑End Frameworks (Client-seitige Entwicklung)**
+
+  * **React** – Marktführer mit einem sehr großen Ökosystem; flexibel, aber etwas konfigurationsintensiv. Ideal, wenn ihr viel Individualisierung braucht und bereit seid, viele Bibliotheken selbst zu kombinieren.
+
+  * **Vue.js** – leichter Einstieg, klare Struktur, gute Mischung aus Flexibilität und Voreinstellungen. Sinnvoll, wenn das Team schnell produktiv werden soll.
+
+  * **Angular** – sehr umfassend und strikt strukturiert; eignet sich gut für größere Projekte mit vielen Entwicklern, da es klare Best Practices vorgibt.
+
+  * **Svelte** – kompakt und performancestark, mit Compiler-basiertem Ansatz. Interessant, wenn ihr minimalistische Bundles und hohe Performance braucht.
+
+
+
+
+**Full-Stack/SSR Frameworks (Server-seitig oder Hybrid)**
+
+  * **Next.js** (für React) – kombiniert Server-Side Rendering (SSR), statische Generierung und API-Routen. Sehr beliebt für performante, SEO-freundliche Seiten mit React.
+
+  * **Nuxt.js** (für Vue) – analog zu Next.js, aber für Vue. Bietet SSR und statische Generierung out of the box.
+
+  * **SvelteKit** – vergleichbar mit Next/Nuxt, aber für Svelte. Noch nicht so etabliert, aber sehr modern und performant.
+
+  * **Gatsby** – baut auf React auf und richtet sich besonders an statische Seiten (JAMstack). Gut für Content-driven Seiten, aber kann bei dynamischen Features komplexer werden.
+
+
+
+
+**Back-End Frameworks (Server-seitig)**
+
+  * **Express** (Node.js) – minimalistisch, flexibel, ideal für REST-APIs oder als Basis für eigene Architekturen.
+
+  * **NestJS** – baut auf Express/Fastify auf, strukturiert wie Angular; eignet sich für größere TypeScript-basierte Projekte.
+
+  * **Django** (Python) – sehr ausgereift, enthält viele Funktionen (ORM, Admin-Interface, Authentifizierung). Besonders geeignet, wenn ihr Python bevorzugt und schnell ein robustes Backend möchtet.
+
+  * **Ruby on Rails** – “Convention over Configuration”; schneller Einstieg und produktive Entwicklung für datengetriebene Anwendungen.
+
+  * **Laravel** (PHP) – moderner PHP-Framework-Klassiker; besonders gut, wenn bereits PHP-Erfahrung vorhanden ist.
+
+
+
+
+**Static Site Generators / CMS**
+
+  * **Hugo** und **Jekyll** – sehr beliebt für reine Content-Seiten oder Dokumentation, wenn keine umfangreiche Backend-Logik benötigt wird.
+
+  * **Strapi** (Headless CMS) – wenn ihr ein flexibles Backend mit UI für Content-Editoren braucht und das Frontend frei wählen wollt.
+
+  * **Contentful** , **Sanity** , **Directus** – vergleichbare Headless-CMS-Lösungen, teils als SaaS.
+
+
+
+
+* * *
+
+**Was positiv herausstechen kann**
+
+  * **Next.js und Nuxt.js** sind derzeit sehr beliebt, weil sie die Vorteile von Client- und Server-Seite verbinden und für SEO stark sind.
+
+  * **Django** oder **Laravel** glänzen, wenn ihr schnell ein komplettes Backend mit vielen Standardfunktionen braucht.
+
+  * **SvelteKit** und **Svelte** werden oft für Performance und einfache Syntax gelobt, sofern ihr mit ihrem noch relativ jungen Ökosystem zurechtkommt.
+
+  * **Headless CMS** (Strapi/Contentful/etc.) sind besonders attraktiv, wenn Redakteure Inhalte pflegen sollen, ohne die Entwickler zu belasten, und wenn ihr Frontend und Backend entkoppeln wollt.
+
+
+
+
+* * *
+
+**Nächste Schritte / Klärungsfragen**  
+Um passgenaue Empfehlungen zu geben, wäre es hilfreich zu wissen:
+
+  1. Welche Art von Webseite plant ihr? (z. B. Unternehmenspräsenz, E-Commerce-Shop, interaktive App, Blog)
+
+  2. Gibt es Präferenzen bei der Programmiersprache oder bereits vorhandene Skills im Team?
+
+  3. Welche Prioritäten sind euch wichtig? (SEO, Performance, schnelle Entwicklung, Skalierbarkeit, Kosten, Wartungsaufwand)
+
+  4. Wie viel Content soll durch Nicht-Entwickler (Redakteure, Marketing) gepflegt werden?
+
+
+
+
+Mit diesen Informationen kann ich euch gezielter weiterhelfen und konkrete Framework-Kombinationen vorschlagen.
 </antwort1>
 
 <prompt2>
@@ -127,82 +118,68 @@ Den vorläufigen Aufbau der Webseite (Pfad-/URL-Struktur) kannst du der Datei AK
 </prompt2>
 
 <antwort2>
-<div class="p-0! px-4 text-sm leading-5 markdown prose dark:prose-invert w-full break-words dark markdown-new-styling"><p data-start="0" data-end="79">Ja, die Angaben reichen völlig aus, um eine gezieltere Einschätzung zu geben.</p>
-<h2 data-start="81" data-end="129">Kurzfristiger Ansatz (GitHub Pages, statisch)</h2>
-<ul data-start="131" data-end="1585">
-<li data-start="131" data-end="1585">
-<p data-start="133" data-end="285"><strong data-start="133" data-end="152">Eleventy (11ty)</strong><br data-start="152" data-end="155">
-Eure aktuelle Struktur (<code data-start="181" data-end="205">projects/AKSEP/src/...</code>) zeigt bereits eine Eleventy-Konfiguration – das passt gut zu eurem Vorhaben.</p>
-<ul data-start="288" data-end="1585">
-<li data-start="288" data-end="513">
-<p data-start="290" data-end="513"><strong data-start="290" data-end="307">Inhaltspflege</strong>: Texte (z. B. Parteiprogramm, Begriffsklärungen) können als Markdown-Dateien im <code data-start="388" data-end="394">src/</code>-Verzeichnis liegen. Eleventy rendert sie zu HTML; Styles und Templates kommen aus <code data-start="477" data-end="489">src/assets</code> bzw. <code data-start="495" data-end="510">src/templates</code>.</p>
-</li>
-<li data-start="516" data-end="839">
-<p data-start="518" data-end="839"><strong data-start="518" data-end="553">Mehrere Versionen des Programms</strong>: Legt pro Version (lang/mittel/kurz/leichte Sprache) Unterordner an, wie es schon für <code data-start="640" data-end="655">Programm/kurz</code> bzw. <code data-start="661" data-end="678">Programm/mittel</code> geschieht. Eine kleine JSON-Datei in <code data-start="716" data-end="735">src/data/program/</code> kann Metadaten (Titel, Sprache, Länge) bündeln, sodass Eleventy automatisch passende Seiten erstellt.</p>
-</li>
-<li data-start="842" data-end="1098">
-<p data-start="844" data-end="1098"><strong data-start="844" data-end="865">Begriffsklärungen</strong>: Ihr habt bereits <code data-start="884" data-end="922">src/de/Begriffe/&lt;Begriff&gt;/index.html</code>. Um spätere Pflege zu erleichtern, könnt ihr diese Begriffe als Markdown-Dateien plus Metadaten (Front Matter) speichern. Eleventy erzeugt dann die HTML-Dateien automatisch.</p>
-</li>
-<li data-start="1101" data-end="1372">
-<p data-start="1103" data-end="1372"><strong data-start="1103" data-end="1132">Zentrale Styles &amp; Skripte</strong>: Die vorhandenen <code data-start="1150" data-end="1160">base.css</code>, <code data-start="1162" data-end="1174">layout.css</code>, <code data-start="1176" data-end="1191">variables.css</code> und JS-Dateien (<code data-start="1208" data-end="1226">cookie-banner.js</code>, <code data-start="1228" data-end="1245">theme-toggle.js</code>) lassen sich in Eleventy-Layouts (<code data-start="1280" data-end="1307">src/templates/layout.html</code>) einbinden, sodass ihr jede Inhaltsseite schlank halten könnt.</p>
-</li>
-<li data-start="1375" data-end="1585">
-<p data-start="1377" data-end="1585"><strong data-start="1377" data-end="1391">Deployment</strong>: GitHub Pages kann direkt aus dem <code data-start="1426" data-end="1433">docs/</code>-Ordner oder einem <code data-start="1452" data-end="1462">gh-pages</code>-Branch veröffentlichen. Eleventy kann per Build-Schritt (z. B. <code data-start="1526" data-end="1541">npm run build</code>) den Inhalt von <code data-start="1558" data-end="1563">src</code> nach <code data-start="1569" data-end="1575">docs</code> ausgeben.</p>
-</li>
-</ul>
-</li>
-</ul>
-<h2 data-start="1587" data-end="1644">Mittelfristiger Ausbau (Content-Pflege, SEO, Struktur)</h2>
-<ul data-start="1646" data-end="2508">
-<li data-start="1646" data-end="2040">
-<p data-start="1648" data-end="2040"><strong data-start="1648" data-end="1684">Versionierung &amp; einfache Sprache</strong>: Um die drei Längen plus „leichte Sprache“ sauber zu verwalten, lohnt sich eine dateibasierte Struktur wie <code data-start="1792" data-end="1813">programm/lang/de.md</code>, <code data-start="1815" data-end="1852">programm/lang/de-leichte-sprache.md</code> usw. Eleventy kann aus den Dateinamen oder Front-Matter-Feldern (z. B. <code data-start="1924" data-end="1938">length: long</code>, <code data-start="1940" data-end="1950">lang: de</code>, <code data-start="1952" data-end="1967">level: simple</code>) URLs generieren (<code data-start="1986" data-end="2005">/de/programm/lang</code>, <code data-start="2007" data-end="2034">/de/programm/lang/einfach</code> …).</p>
-</li>
-<li data-start="2041" data-end="2295">
-<p data-start="2043" data-end="2295"><strong data-start="2043" data-end="2050">SEO</strong>: Achtet auf eindeutige <code data-start="2074" data-end="2081">title</code>‑ und <code data-start="2087" data-end="2105">meta description</code>‑Felder; Eleventy erlaubt Front-Matter-Variablen, die ihr im Layout ausgebt. Für Suchmaschinenfreundlichkeit könnt ihr zusätzlich eine Sitemap generieren (<code data-start="2260" data-end="2291">@11ty/eleventy-plugin-sitemap</code>).</p>
-</li>
-<li data-start="2296" data-end="2508">
-<p data-start="2298" data-end="2508"><strong data-start="2298" data-end="2312">Navigation</strong>: Eine zentrale JSON/Markdown-Datei im <code data-start="2351" data-end="2362">src/data/</code>-Ordner kann Navigationspunkte definieren (z. B. Parteiprogramm, Begriffsklärungen, Kontakt). Eleventy-Layouts bauen daraus automatisch die Menüs.</p>
-</li>
-</ul>
-<h2 data-start="2510" data-end="2576">Langfristige Perspektive (dynamische Inhalte, Redaktionssystem)</h2>
-<ul data-start="2578" data-end="3640">
-<li data-start="2578" data-end="3023">
-<p data-start="2580" data-end="2625"><strong data-start="2580" data-end="2622">Headless CMS / Git-basierte Editierung</strong>:</p>
-<ul data-start="2628" data-end="3023">
-<li data-start="2628" data-end="2840">
-<p data-start="2630" data-end="2840"><em data-start="2630" data-end="2651">Git-basierte Lösung</em>: Netlify CMS oder TinaCMS integriert sich mit Eleventy und speichert Inhalte im Repository. Redakteure könnten so per Browser Beiträge verfassen, ohne Node.js-Builds manuell auszuführen.</p>
-</li>
-<li data-start="2843" data-end="3023">
-<p data-start="2845" data-end="3023"><em data-start="2845" data-end="2865">Eigenständiges CMS</em>: Strapi oder Directus liefern ein API-basiertes Backend. Für GitHub Pages benötigt ihr dann einen statischen Exporter oder ein separates Hosting für das CMS.</p>
-</li>
-</ul>
-</li>
-<li data-start="3024" data-end="3333">
-<p data-start="3026" data-end="3333"><strong data-start="3026" data-end="3048">Dynamische Web-App</strong>: Wenn ihr später Kommentare, Accounts oder Foren einführt, bieten sich Fullstack-Frameworks wie <strong data-start="3145" data-end="3156">Next.js</strong> (React), <strong data-start="3166" data-end="3177">Nuxt.js</strong> (Vue) oder <strong data-start="3189" data-end="3202">SvelteKit</strong> an. Diese können anfangs ebenfalls statisch exportieren, lassen sich jedoch bei Bedarf zu Server- oder Serverless-Apps ausbauen.</p>
-</li>
-<li data-start="3334" data-end="3640">
-<p data-start="3336" data-end="3640"><strong data-start="3336" data-end="3359">Wikipedia-Vergleich</strong>: Wikipedia nutzt <em data-start="3377" data-end="3388">MediaWiki</em> (PHP, MySQL). Das ist sehr mächtig, aber komplex. Wenn ihr ein eigenes „Mini-Wiki“ plant, wäre ein leichtgewichtiges Wiki-Framework (z. B. DokuWiki, Grav) oder ein statischer Wiki-Generator (z. B. Wiki.js mit statischem Export) ein möglicher Einstieg.</p>
-</li>
-</ul>
-<h2 data-start="3642" data-end="3684">Empfehlungen für eure nächsten Schritte</h2>
-<ol data-start="3686" data-end="4519">
-<li data-start="3686" data-end="3826">
-<p data-start="3689" data-end="3826"><strong data-start="3689" data-end="3710">Eleventy ausbauen</strong> – nutzt Markdown + Front Matter, um die Vielzahl an Programmseiten und Begriffsklärungen strukturiert zu pflegen.</p>
-</li>
-<li data-start="3827" data-end="4016">
-<p data-start="3830" data-end="4016"><strong data-start="3830" data-end="3864">Strikte Ordner-/URL-Konvention</strong> – spiegelt eure geplante Navigation („/de/Programm/mittel/…“, „/de/Begriffe/Faschismus/…“ usw.), damit Links stabil bleiben, wenn ihr später umzieht.</p>
-</li>
-<li data-start="4017" data-end="4129">
-<p data-start="4020" data-end="4129"><strong data-start="4020" data-end="4039">SEO &amp; Metadaten</strong> – füllt für jede Seite <code data-start="4063" data-end="4070">title</code>, <code data-start="4072" data-end="4085">description</code>, Open-Graph‑Tags, und prüft eine Sitemap.</p>
-</li>
-<li data-start="4130" data-end="4311">
-<p data-start="4133" data-end="4311"><strong data-start="4133" data-end="4167">Content-Management vorbereiten</strong> – entscheidet früh, ob ihr langfristig auf ein Headless CMS oder eine Git-basierte Lösung setzt; das beeinflusst Dateistruktur und Metadaten.</p>
-</li>
-<li data-start="4312" data-end="4519">
-<p data-start="4315" data-end="4519"><strong data-start="4315" data-end="4337">Zukunftssicherheit</strong> – behaltet im Hinterkopf, welche Features (Kommentare, Accounts, Forum) ihr später wollt. So könnt ihr später auf ein dynamisches Framework migrieren, ohne komplett neu zu beginnen.</p>
-</li>
-</ol>
-<p data-start="4521" data-end="4709" data-is-last-node="" data-is-only-node="">Wenn euch zu einzelnen Punkten (z. B. Eleventy-Layouts, Metadatenstruktur, Wahl eines CMS) weitere Detailfragen einfallen, sag gern Bescheid; ich unterstütze euch gern Schritt für Schritt.</p></div>
+Ja, die Angaben reichen völlig aus, um eine gezieltere Einschätzung zu geben.
+
+## Kurzfristiger Ansatz (GitHub Pages, statisch)
+
+  * **Eleventy (11ty)**  
+Eure aktuelle Struktur (`projects/AKSEP/src/...`) zeigt bereits eine Eleventy-Konfiguration – das passt gut zu eurem Vorhaben.
+
+    * **Inhaltspflege** : Texte (z. B. Parteiprogramm, Begriffsklärungen) können als Markdown-Dateien im `src/`-Verzeichnis liegen. Eleventy rendert sie zu HTML; Styles und Templates kommen aus `src/assets` bzw. `src/templates`.
+
+    * **Mehrere Versionen des Programms** : Legt pro Version (lang/mittel/kurz/leichte Sprache) Unterordner an, wie es schon für `Programm/kurz` bzw. `Programm/mittel` geschieht. Eine kleine JSON-Datei in `src/data/program/` kann Metadaten (Titel, Sprache, Länge) bündeln, sodass Eleventy automatisch passende Seiten erstellt.
+
+    * **Begriffsklärungen** : Ihr habt bereits `src/de/Begriffe/<Begriff>/index.html`. Um spätere Pflege zu erleichtern, könnt ihr diese Begriffe als Markdown-Dateien plus Metadaten (Front Matter) speichern. Eleventy erzeugt dann die HTML-Dateien automatisch.
+
+    * **Zentrale Styles & Skripte**: Die vorhandenen `base.css`, `layout.css`, `variables.css` und JS-Dateien (`cookie-banner.js`, `theme-toggle.js`) lassen sich in Eleventy-Layouts (`src/templates/layout.html`) einbinden, sodass ihr jede Inhaltsseite schlank halten könnt.
+
+    * **Deployment** : GitHub Pages kann direkt aus dem `docs/`-Ordner oder einem `gh-pages`-Branch veröffentlichen. Eleventy kann per Build-Schritt (z. B. `npm run build`) den Inhalt von `src` nach `docs` ausgeben.
+
+
+
+
+## Mittelfristiger Ausbau (Content-Pflege, SEO, Struktur)
+
+  * **Versionierung & einfache Sprache**: Um die drei Längen plus „leichte Sprache“ sauber zu verwalten, lohnt sich eine dateibasierte Struktur wie `programm/lang/de.md`, `programm/lang/de-leichte-sprache.md` usw. Eleventy kann aus den Dateinamen oder Front-Matter-Feldern (z. B. `length: long`, `lang: de`, `level: simple`) URLs generieren (`/de/programm/lang`, `/de/programm/lang/einfach` …).
+
+  * **SEO** : Achtet auf eindeutige `title`‑ und `meta description`‑Felder; Eleventy erlaubt Front-Matter-Variablen, die ihr im Layout ausgebt. Für Suchmaschinenfreundlichkeit könnt ihr zusätzlich eine Sitemap generieren (`@11ty/eleventy-plugin-sitemap`).
+
+  * **Navigation** : Eine zentrale JSON/Markdown-Datei im `src/data/`-Ordner kann Navigationspunkte definieren (z. B. Parteiprogramm, Begriffsklärungen, Kontakt). Eleventy-Layouts bauen daraus automatisch die Menüs.
+
+
+
+
+## Langfristige Perspektive (dynamische Inhalte, Redaktionssystem)
+
+  * **Headless CMS / Git-basierte Editierung** :
+
+    * _Git-basierte Lösung_ : Netlify CMS oder TinaCMS integriert sich mit Eleventy und speichert Inhalte im Repository. Redakteure könnten so per Browser Beiträge verfassen, ohne Node.js-Builds manuell auszuführen.
+
+    * _Eigenständiges CMS_ : Strapi oder Directus liefern ein API-basiertes Backend. Für GitHub Pages benötigt ihr dann einen statischen Exporter oder ein separates Hosting für das CMS.
+
+  * **Dynamische Web-App** : Wenn ihr später Kommentare, Accounts oder Foren einführt, bieten sich Fullstack-Frameworks wie **Next.js** (React), **Nuxt.js** (Vue) oder **SvelteKit** an. Diese können anfangs ebenfalls statisch exportieren, lassen sich jedoch bei Bedarf zu Server- oder Serverless-Apps ausbauen.
+
+  * **Wikipedia-Vergleich** : Wikipedia nutzt _MediaWiki_ (PHP, MySQL). Das ist sehr mächtig, aber komplex. Wenn ihr ein eigenes „Mini-Wiki“ plant, wäre ein leichtgewichtiges Wiki-Framework (z. B. DokuWiki, Grav) oder ein statischer Wiki-Generator (z. B. Wiki.js mit statischem Export) ein möglicher Einstieg.
+
+
+
+
+## Empfehlungen für eure nächsten Schritte
+
+  1. **Eleventy ausbauen** – nutzt Markdown + Front Matter, um die Vielzahl an Programmseiten und Begriffsklärungen strukturiert zu pflegen.
+
+  2. **Strikte Ordner-/URL-Konvention** – spiegelt eure geplante Navigation („/de/Programm/mittel/…“, „/de/Begriffe/Faschismus/…“ usw.), damit Links stabil bleiben, wenn ihr später umzieht.
+
+  3. **SEO & Metadaten** – füllt für jede Seite `title`, `description`, Open-Graph‑Tags, und prüft eine Sitemap.
+
+  4. **Content-Management vorbereiten** – entscheidet früh, ob ihr langfristig auf ein Headless CMS oder eine Git-basierte Lösung setzt; das beeinflusst Dateistruktur und Metadaten.
+
+  5. **Zukunftssicherheit** – behaltet im Hinterkopf, welche Features (Kommentare, Accounts, Forum) ihr später wollt. So könnt ihr später auf ein dynamisches Framework migrieren, ohne komplett neu zu beginnen.
+
+
+
+
+Wenn euch zu einzelnen Punkten (z. B. Eleventy-Layouts, Metadatenstruktur, Wahl eines CMS) weitere Detailfragen einfallen, sag gern Bescheid; ich unterstütze euch gern Schritt für Schritt.
 </antwort2>
 
 <prompt3>
@@ -226,79 +203,88 @@ Hast du noch Ergänzungen/Klarstellungen/Einordnungen zu meinen Antworten (zusä
 </prompt3>
 
 <antwort3>
-<div class="p-0! px-4 text-sm leading-5 markdown prose dark:prose-invert w-full break-words dark markdown-new-styling"><h3 data-start="0" data-end="44">1. Markdown + Front Matter in Eleventy</h3>
-<ul data-start="45" data-end="1351">
-<li data-start="45" data-end="211">
-<p data-start="47" data-end="211"><strong data-start="47" data-end="59">Struktur</strong>: Ihr könnt die bestehende Ordnerhierarchie (<code data-start="104" data-end="125">src/de/Programm/...</code>) beibehalten und darin die bisherigen <code data-start="164" data-end="171">.html</code>‑Dateien durch <code data-start="186" data-end="191">.md</code>‑Dateien ersetzen.</p>
-</li>
-<li data-start="212" data-end="583">
-<p data-start="214" data-end="583"><strong data-start="214" data-end="227">Zerlegung</strong>: Statt das komplette Parteiprogramm in eine einzige <code data-start="280" data-end="285">.md</code> zu packen, ist es sinnvoll, für jede Variante (lang/mittel/kurz, jeweils in einfacher Sprache) einen Ordner bzw. Unterordner zu führen. Innerhalb dieser Ordner könnt ihr das Programm kapitelweise aufteilen (<code data-start="493" data-end="511">01-einleitung.md</code>, <code data-start="513" data-end="531">02-grundwerte.md</code> usw.), sodass jede Seite leichter wartbar bleibt.</p>
-</li>
-<li data-start="584" data-end="1072">
-<p data-start="586" data-end="677"><strong data-start="586" data-end="602">Front Matter</strong>: Oben in jeder Markdown-Datei steht ein YAML-Block mit Metadaten, z. B.:</p>
-<pre class="overflow-visible!" data-start="680" data-end="875"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="flex items-center text-token-text-secondary px-4 py-2 text-xs font-sans justify-between h-9 bg-token-sidebar-surface-primary select-none rounded-t-2xl">yaml</div><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"><button class="flex gap-1 items-center select-none py-1" aria-label="Kopieren"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="icon-xs"><path d="..."></path></svg>Kopieren</button></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-yaml"><span><span><span class="hljs-meta">---</span></span><span>
-</span><span><span class="hljs-attr">title:</span></span><span> </span><span><span class="hljs-string">"Parteiprogramm – Langfassung"</span></span><span>
-</span><span><span class="hljs-attr">layout:</span></span><span> </span><span><span class="hljs-string">"layouts/program.html"</span></span><span>
-</span><span><span class="hljs-attr">permalink:</span></span><span> </span><span><span class="hljs-string">"/de/Programm/lang/"</span></span><span>
-</span><span><span class="hljs-attr">description:</span></span><span> </span><span><span class="hljs-string">"Langfassung des Parteiprogramms der AKSEP …"</span></span><span>
-<span class="hljs-meta">---
-</span></span></span></code></div></div></pre>
-<p data-start="878" data-end="1072">Der <code data-start="882" data-end="890">layout</code>-Wert verweist auf eine zentrale HTML-Vorlage, die eure Styles (<code data-start="954" data-end="973">/assets/css/*.css</code>) einbindet. Der Markdown-Body wird automatisch in den <code data-start="1028" data-end="1036">&lt;main&gt;</code>‑Bereich dieses Layouts gerendert.</p>
-</li>
-<li data-start="1073" data-end="1351">
-<p data-start="1075" data-end="1351"><strong data-start="1075" data-end="1094">Zentrale Styles</strong>: Alle Seiten nutzen dieselben Styles, weil ihr in <code data-start="1145" data-end="1167">layouts/program.html</code> (oder einem generischen <code data-start="1192" data-end="1205">layout.html</code>) die CSS-Dateien (<code data-start="1224" data-end="1234">base.css</code>, <code data-start="1236" data-end="1248">layout.css</code>, <code data-start="1250" data-end="1265">variables.css</code>) einmalig referenziert. Jede Markdown-Seite erbt dieses Layout über ihr Front Matter.</p>
-</li>
-</ul>
-<p data-start="1353" data-end="1373"><strong data-start="1353" data-end="1371">Worauf achten?</strong></p>
-<ol data-start="1374" data-end="1951">
-<li data-start="1374" data-end="1525">
-<p data-start="1377" data-end="1525"><strong data-start="1377" data-end="1391">Permalinks</strong>: Mit <code data-start="1397" data-end="1408">permalink</code> im Front Matter könnt ihr steuern, unter welcher URL die Seite erscheint – sehr wichtig für SEO und stabile Links.</p>
-</li>
-<li data-start="1526" data-end="1612">
-<p data-start="1529" data-end="1612"><strong data-start="1529" data-end="1543">Dateinamen</strong>: Sinnvolle, sprechende Namen erleichtern spätere Suche und Pflege.</p>
-</li>
-<li data-start="1613" data-end="1779">
-<p data-start="1616" data-end="1779"><strong data-start="1616" data-end="1629">Metadaten</strong>: <code data-start="1631" data-end="1638">title</code>, <code data-start="1640" data-end="1653">description</code>, optional <code data-start="1664" data-end="1670">tags</code> oder <code data-start="1676" data-end="1682">lang</code> im Front Matter hinterlegen; Eleventy kann daraus Meta-Tags oder Navigationslisten generieren.</p>
-</li>
-<li data-start="1780" data-end="1951">
-<p data-start="1783" data-end="1951"><strong data-start="1783" data-end="1802">Includes/Layout</strong>: Nutzt das Layout für wiederkehrende Elemente (Header, Footer, Breadcrumbs). Dadurch bleibt jede Markdown-Datei nur für den Inhalt verantwortlich.</p>
-</li>
-</ol>
-<hr data-start="1953" data-end="1956">
-<h3 data-start="1958" data-end="1989">2. Ordner-/URL-Konvention</h3>
-<p data-start="1990" data-end="2118">Die Empfehlung, Struktur und URLs zu spiegeln, zielt darauf ab, dass <strong data-start="2059" data-end="2108">Dateipfad und endgültige URL synchron bleiben</strong>, damit:</p>
-<ul data-start="2119" data-end="2338">
-<li data-start="2119" data-end="2189">
-<p data-start="2121" data-end="2189">interne Links (z. B. <code data-start="2142" data-end="2164">/de/Programm/mittel/</code>) stabil funktionieren,</p>
-</li>
-<li data-start="2190" data-end="2338">
-<p data-start="2192" data-end="2338">ein späterer Umzug auf ein anderes Hosting oder Framework einfacher ist (ihr könnt die Ordner direkt übernehmen oder automatisiert exportieren).</p>
-</li>
-</ul>
-<p data-start="2340" data-end="2519">Wenn ihr ohnehin alles rüberkopiert, seid ihr im Prinzip schon auf dem richtigen Weg. Achtet nur darauf, dass jede Seite genau an dem Pfad liegt, den ihr öffentlich als URL nutzt.</p>
-<hr data-start="2521" data-end="2524">
-<h3 data-start="2526" data-end="2550">3. SEO &amp; Metadaten</h3>
-<p data-start="2551" data-end="2846">Korrekt – ihr könnt Metadaten Schritt für Schritt ergänzen. Eleventy erlaubt, standardisierte Felder (z. B. <code data-start="2659" data-end="2666">title</code>, <code data-start="2668" data-end="2681">description</code>, Open‑Graph‑Tags) im Layout zu rendern. Wenn ihr später eine Sitemap braucht, kann ein Eleventy-Plugin (<code data-start="2786" data-end="2817">@11ty/eleventy-plugin-sitemap</code>) diese automatisch erzeugen.</p>
-<hr data-start="2848" data-end="2851">
-<h3 data-start="2853" data-end="2890">4. Content-Management &amp; Hosting</h3>
-<ul data-start="2891" data-end="3441">
-<li data-start="2891" data-end="3189">
-<p data-start="2893" data-end="3189">Dass ihr langfristig auf eigene Domains (<code data-start="2934" data-end="2943">aksp.de</code>, <code data-start="2945" data-end="2954">aksp.ch</code> usw.) umsteigen wollt, passt. Eure momentane Struktur in <code data-start="3012" data-end="3018">src/</code> bleibt weiterhin nutzbar; beim Deployment auf GitHub Pages oder späterem Hosting wird einfach das generierte Output-Verzeichnis (z. B. <code data-start="3154" data-end="3161">_site</code> oder <code data-start="3167" data-end="3173">docs</code>) hochgeladen.</p>
-</li>
-<li data-start="3190" data-end="3441">
-<p data-start="3192" data-end="3441">Entscheidet später, ob ihr ein Headless CMS (Strapi, Contentful) oder eine Git-basierte Lösung (Netlify CMS, Tina) nutzen wollt. Diese Wahl beeinflusst lediglich, <strong data-start="3355" data-end="3362">wie</strong> die Markdown-Dateien gepflegt werden – eure Dateistruktur kann gleich bleiben.</p>
-</li>
-</ul>
-<hr data-start="3443" data-end="3446">
-<h3 data-start="3448" data-end="3475">5. Zukunftssicherheit</h3>
-<ul data-start="3476" data-end="3848">
-<li data-start="3476" data-end="3612">
-<p data-start="3478" data-end="3612">Platzhalter für kommende Features (Kommentare, Login, Forum) könnt ihr als separate Sektionen oder TODO-Kommentare im Code vorsehen.</p>
-</li>
-<li data-start="3613" data-end="3848">
-<p data-start="3615" data-end="3848">Legt früh fest, wie ihr Benutzerrollen oder dynamische Inhalte einbinden möchtet, damit ihr später mit einem Framework wie Next.js/Nuxt.js/SvelteKit nahtlos weiterarbeiten könnt, ohne den gesamten Content neu strukturieren zu müssen.</p>
-</li>
-</ul>
-<hr data-start="3850" data-end="3853">
-<p data-start="3855" data-end="4001" data-is-last-node="" data-is-only-node="">Falls du zu einzelnen Punkten konkretere Anleitungen brauchst (z. B. Beispiel-Layout-Datei oder Eleventy-Build-Konfiguration), sag gerne Bescheid!</p></div>
+### 1\. Markdown + Front Matter in Eleventy
+
+  * **Struktur** : Ihr könnt die bestehende Ordnerhierarchie (`src/de/Programm/...`) beibehalten und darin die bisherigen `.html`‑Dateien durch `.md`‑Dateien ersetzen.
+
+  * **Zerlegung** : Statt das komplette Parteiprogramm in eine einzige `.md` zu packen, ist es sinnvoll, für jede Variante (lang/mittel/kurz, jeweils in einfacher Sprache) einen Ordner bzw. Unterordner zu führen. Innerhalb dieser Ordner könnt ihr das Programm kapitelweise aufteilen (`01-einleitung.md`, `02-grundwerte.md` usw.), sodass jede Seite leichter wartbar bleibt.
+
+  * **Front Matter** : Oben in jeder Markdown-Datei steht ein YAML-Block mit Metadaten, z. B.:
+
+        ```yaml
+        ---
+        title: "Parteiprogramm – Langfassung"
+        layout: "layouts/program.html"
+        permalink: "/de/Programm/lang/"
+        description: "Langfassung des Parteiprogramms der AKSEP …"
+        ---
+        ```
+
+
+Der `layout`-Wert verweist auf eine zentrale HTML-Vorlage, die eure Styles (`/assets/css/*.css`) einbindet. Der Markdown-Body wird automatisch in den `<main>`‑Bereich dieses Layouts gerendert.
+
+  * **Zentrale Styles** : Alle Seiten nutzen dieselben Styles, weil ihr in `layouts/program.html` (oder einem generischen `layout.html`) die CSS-Dateien (`base.css`, `layout.css`, `variables.css`) einmalig referenziert. Jede Markdown-Seite erbt dieses Layout über ihr Front Matter.
+
+
+
+
+**Worauf achten?**
+
+  1. **Permalinks** : Mit `permalink` im Front Matter könnt ihr steuern, unter welcher URL die Seite erscheint – sehr wichtig für SEO und stabile Links.
+
+  2. **Dateinamen** : Sinnvolle, sprechende Namen erleichtern spätere Suche und Pflege.
+
+  3. **Metadaten** : `title`, `description`, optional `tags` oder `lang` im Front Matter hinterlegen; Eleventy kann daraus Meta-Tags oder Navigationslisten generieren.
+
+  4. **Includes/Layout** : Nutzt das Layout für wiederkehrende Elemente (Header, Footer, Breadcrumbs). Dadurch bleibt jede Markdown-Datei nur für den Inhalt verantwortlich.
+
+
+
+
+* * *
+
+### 2\. Ordner-/URL-Konvention
+
+Die Empfehlung, Struktur und URLs zu spiegeln, zielt darauf ab, dass **Dateipfad und endgültige URL synchron bleiben** , damit:
+
+  * interne Links (z. B. `/de/Programm/mittel/`) stabil funktionieren,
+
+  * ein späterer Umzug auf ein anderes Hosting oder Framework einfacher ist (ihr könnt die Ordner direkt übernehmen oder automatisiert exportieren).
+
+
+
+
+Wenn ihr ohnehin alles rüberkopiert, seid ihr im Prinzip schon auf dem richtigen Weg. Achtet nur darauf, dass jede Seite genau an dem Pfad liegt, den ihr öffentlich als URL nutzt.
+
+* * *
+
+### 3\. SEO & Metadaten
+
+Korrekt – ihr könnt Metadaten Schritt für Schritt ergänzen. Eleventy erlaubt, standardisierte Felder (z. B. `title`, `description`, Open‑Graph‑Tags) im Layout zu rendern. Wenn ihr später eine Sitemap braucht, kann ein Eleventy-Plugin (`@11ty/eleventy-plugin-sitemap`) diese automatisch erzeugen.
+
+* * *
+
+### 4\. Content-Management & Hosting
+
+  * Dass ihr langfristig auf eigene Domains (`aksp.de`, `aksp.ch` usw.) umsteigen wollt, passt. Eure momentane Struktur in `src/` bleibt weiterhin nutzbar; beim Deployment auf GitHub Pages oder späterem Hosting wird einfach das generierte Output-Verzeichnis (z. B. `_site` oder `docs`) hochgeladen.
+
+  * Entscheidet später, ob ihr ein Headless CMS (Strapi, Contentful) oder eine Git-basierte Lösung (Netlify CMS, Tina) nutzen wollt. Diese Wahl beeinflusst lediglich, **wie** die Markdown-Dateien gepflegt werden – eure Dateistruktur kann gleich bleiben.
+
+
+
+
+* * *
+
+### 5\. Zukunftssicherheit
+
+  * Platzhalter für kommende Features (Kommentare, Login, Forum) könnt ihr als separate Sektionen oder TODO-Kommentare im Code vorsehen.
+
+  * Legt früh fest, wie ihr Benutzerrollen oder dynamische Inhalte einbinden möchtet, damit ihr später mit einem Framework wie Next.js/Nuxt.js/SvelteKit nahtlos weiterarbeiten könnt, ohne den gesamten Content neu strukturieren zu müssen.
+
+
+
+
+* * *
+
+Falls du zu einzelnen Punkten konkretere Anleitungen brauchst (z. B. Beispiel-Layout-Datei oder Eleventy-Build-Konfiguration), sag gerne Bescheid!
 </antwort3>


### PR DESCRIPTION
## Summary
- Normalize `Planung.md` to plain Markdown while preserving the custom `<prompt>`/`<antwort>` markers and sample YAML front matter.
- Reference the new `Planung.md` planning document in `AGENTS.md` for future guidance on the website structure.

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix projects/AKSEP run build`


------
https://chatgpt.com/codex/tasks/task_e_6893311b0d908333a96e57351f859cdb