### PR TITLE
[AKSEP]: convert kurz and mittel program pages to markdown

### DIFF
--- a/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Agrarpolitik"
+---
+
+# {{ title }}
+
+AG 14
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik/index.html
@@ -1,2 +1,0 @@
-<h1>AG Agrarpolitik</h1>
-<p>AG 14</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Aussenpolitik"
+---
+
+# {{ title }}
+
+AG 11
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik/index.html
@@ -1,2 +1,0 @@
-<h1>AG Aussenpolitik</h1>
-<p>AG 11</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Europa und Migration"
+---
+
+# {{ title }}
+
+AG 10
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration/index.html
@@ -1,2 +1,0 @@
-<h1>AG Europa und Migration</h1>
-<p>AG 10</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Forschung und KI"
+---
+
+# {{ title }}
+
+AG 6
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI/index.html
@@ -1,2 +1,0 @@
-<h1>AG Forschung und KI</h1>
-<p>AG 6</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Gesundheit"
+---
+
+# {{ title }}
+
+AG 5
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit/index.html
@@ -1,2 +1,0 @@
-<h1>AG Gesundheit</h1>
-<p>AG 5</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Innere Sicherheit"
+---
+
+# {{ title }}
+
+AG 2
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit/index.html
@@ -1,2 +1,0 @@
-<h1>AG Innere Sicherheit</h1>
-<p>AG 2</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Klimaschutz"
+---
+
+# {{ title }}
+
+AG 4
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz/index.html
@@ -1,2 +1,0 @@
-<h1>AG Klimaschutz</h1>
-<p>AG 4</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Regierung.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Regierung.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Regierung"
+---
+
+# {{ title }}
+
+AG 1
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Regierung/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Regierung/index.html
@@ -1,2 +1,0 @@
-<h1>AG Regierung</h1>
-<p>AG 1</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "'AG' Sonstiges"
+---
+
+# {{ title }}
+
+AG 13
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges/index.html
@@ -1,2 +1,0 @@
-<h1>'AG' Sonstiges</h1>
-<p>AG 13</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Soziales.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Soziales.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Soziales"
+---
+
+# {{ title }}
+
+AG 9
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Soziales/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Soziales/index.html
@@ -1,2 +1,0 @@
-<h1>AG Soziales</h1>
-<p>AG 9</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Tierrechte"
+---
+
+# {{ title }}
+
+AG 12
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte/index.html
@@ -1,2 +1,0 @@
-<h1>AG Tierrechte</h1>
-<p>AG 12</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Umweltschutz"
+---
+
+# {{ title }}
+
+AG 3
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz/index.html
@@ -1,2 +1,0 @@
-<h1>AG Umweltschutz</h1>
-<p>AG 3</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Weiter-Bildung"
+---
+
+# {{ title }}
+
+AG 8
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung/index.html
@@ -1,2 +1,0 @@
-<h1>AG Weiter-Bildung</h1>
-<p>AG 8</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Wirtschaft"
+---
+
+# {{ title }}
+
+AG 7
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft/index.html
@@ -1,2 +1,0 @@
-<h1>AG Wirtschaft</h1>
-<p>AG 7</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Warum eine Ernaehrungsreform notwendig ist"
+---
+
+# {{ title }}
+
+AG 13
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform/index.html
@@ -1,3 +1,0 @@
-<h1>Warum eine Ernaehrungsreform notwendig ist</h1>
-<p>AG 13</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Aktive Neutralitaet "
+---
+
+# {{ title }}
+
+AG 11
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet/index.html
@@ -1,3 +1,0 @@
-<h1>Aktive Neutralitaet </h1>
-<p>AG 11</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes Europa"
+---
+
+# {{ title }}
+
+AG 10
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/index.html
@@ -1,3 +1,0 @@
-<h1>Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes Europa</h1>
-<p>AG 10</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen"
+---
+
+# {{ title }}
+
+AG 5
+
+Thema 3
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/index.html
@@ -1,3 +1,0 @@
-<h1>Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen</h1>
-<p>AG 5</p>
-<p>Thema 3</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Reservepool für Pflegefachkräfte"
+---
+
+# {{ title }}
+
+AG 5
+
+Thema 2
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/index.html
@@ -1,3 +1,0 @@
-<h1>Reservepool für Pflegefachkräfte</h1>
-<p>AG 5</p>
-<p>Thema 2</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen"
+---
+
+# {{ title }}
+
+AG 5
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/index.html
@@ -1,3 +1,0 @@
-<h1>öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen</h1>
-<p>AG 5</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Drogenpolitik "
+---
+
+# {{ title }}
+
+AG 2
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik/index.html
@@ -1,3 +1,0 @@
-<h1>Drogenpolitik </h1>
-<p>AG 2</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Project Drawdown"
+---
+
+# {{ title }}
+
+AG 4
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown/index.html
@@ -1,3 +1,0 @@
-<h1>Project Drawdown</h1>
-<p>AG 4</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Regierungsform"
+---
+
+# {{ title }}
+
+AG 1
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform/index.html
@@ -1,3 +1,0 @@
-<h1>Regierungsform</h1>
-<p>AG 1</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Verguetungssystem fuer Amtsinhaber"
+---
+
+# {{ title }}
+
+AG 1
+
+Thema 3
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber/index.html
@@ -1,3 +1,0 @@
-<h1>Verguetungssystem fuer Amtsinhaber</h1>
-<p>AG 1</p>
-<p>Thema 3</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Wahlsystem"
+---
+
+# {{ title }}
+
+AG 1
+
+Thema 2
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem/index.html
@@ -1,3 +1,0 @@
-<h1>Wahlsystem</h1>
-<p>AG 1</p>
-<p>Thema 2</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Religiöse Erziehung"
+---
+
+# {{ title }}
+
+AG 13
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung/index.html
@@ -1,3 +1,0 @@
-<h1>Religiöse Erziehung</h1>
-<p>AG 13</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Grundsatzposition"
+---
+
+# {{ title }}
+
+AG 12
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition/index.html
@@ -1,3 +1,0 @@
-<h1>Grundsatzposition</h1>
-<p>AG 12</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"
+---
+
+# {{ title }}
+
+AG 3
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events/index.html
@@ -1,3 +1,0 @@
-<h1>Zentralisierte Feuerwerk-Events & Förderung alternativer Shows</h1>
-<p>AG 3</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Reform des Bildungssystems [IN UeBERARBEITUNG]"
+---
+
+# {{ title }}
+
+AG 8
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems/index.html
@@ -1,3 +1,0 @@
-<h1>Reform des Bildungssystems [IN UeBERARBEITUNG]</h1>
-<p>AG 8</p>
-<p>Thema 1</p>


### PR DESCRIPTION
## Summary
- replace kurz AG HTML placeholders with Markdown files
- convert mittel topic pages to Markdown for Eleventy

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893642485f8833382e9372c0a40d7aa