### PR TITLE
[AKSEP]: split long program into chapter markdown files

### DIFF
--- a/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Agrarpolitik"
+---
+
+# {{ title }}
+
+AG 14
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik/index.html
@@ -1,2 +1,0 @@
-<h1>AG Agrarpolitik</h1>
-<p>AG 14</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Aussenpolitik"
+---
+
+# {{ title }}
+
+AG 11
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik/index.html
@@ -1,2 +1,0 @@
-<h1>AG Aussenpolitik</h1>
-<p>AG 11</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Europa und Migration"
+---
+
+# {{ title }}
+
+AG 10
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration/index.html
@@ -1,2 +1,0 @@
-<h1>AG Europa und Migration</h1>
-<p>AG 10</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Forschung und KI"
+---
+
+# {{ title }}
+
+AG 6
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI/index.html
@@ -1,2 +1,0 @@
-<h1>AG Forschung und KI</h1>
-<p>AG 6</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Gesundheit"
+---
+
+# {{ title }}
+
+AG 5
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit/index.html
@@ -1,2 +1,0 @@
-<h1>AG Gesundheit</h1>
-<p>AG 5</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Innere Sicherheit"
+---
+
+# {{ title }}
+
+AG 2
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit/index.html
@@ -1,2 +1,0 @@
-<h1>AG Innere Sicherheit</h1>
-<p>AG 2</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Klimaschutz"
+---
+
+# {{ title }}
+
+AG 4
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz/index.html
@@ -1,2 +1,0 @@
-<h1>AG Klimaschutz</h1>
-<p>AG 4</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Regierung.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Regierung.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Regierung"
+---
+
+# {{ title }}
+
+AG 1
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Regierung/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Regierung/index.html
@@ -1,2 +1,0 @@
-<h1>AG Regierung</h1>
-<p>AG 1</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "'AG' Sonstiges"
+---
+
+# {{ title }}
+
+AG 13
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges/index.html
@@ -1,2 +1,0 @@
-<h1>'AG' Sonstiges</h1>
-<p>AG 13</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Soziales.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Soziales.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Soziales"
+---
+
+# {{ title }}
+
+AG 9
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Soziales/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Soziales/index.html
@@ -1,2 +1,0 @@
-<h1>AG Soziales</h1>
-<p>AG 9</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Tierrechte"
+---
+
+# {{ title }}
+
+AG 12
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte/index.html
@@ -1,2 +1,0 @@
-<h1>AG Tierrechte</h1>
-<p>AG 12</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Umweltschutz"
+---
+
+# {{ title }}
+
+AG 3
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz/index.html
@@ -1,2 +1,0 @@
-<h1>AG Umweltschutz</h1>
-<p>AG 3</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Weiter-Bildung"
+---
+
+# {{ title }}
+
+AG 8
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Weiter-Bildung/index.html
@@ -1,2 +1,0 @@
-<h1>AG Weiter-Bildung</h1>
-<p>AG 8</p>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft.md
@@ -1,0 +1,9 @@
+---
+layout: layout.html
+title: "AG Wirtschaft"
+---
+
+# {{ title }}
+
+AG 7
+

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft/index.html
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft/index.html
@@ -1,2 +1,0 @@
-<h1>AG Wirtschaft</h1>
-<p>AG 7</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/01-tierrechte.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/01-tierrechte.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Tierrechte"
+ag_id: 14
+thema_id: 1
+kapitel_id: 1
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Tierrechte
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/02-auswirkungen-gesundheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/02-auswirkungen-gesundheit.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Auswirkungen auf die Gesundheit"
+ag_id: 14
+thema_id: 1
+kapitel_id: 2
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Auswirkungen auf die Gesundheit
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/03-auswirkungen-umwelt.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/03-auswirkungen-umwelt.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Auswirkungen auf Natur und Umwelt"
+ag_id: 14
+thema_id: 1
+kapitel_id: 3
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Auswirkungen auf Natur und Umwelt
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/04-auswirkungen-klima.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/04-auswirkungen-klima.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Auswirkungen auf das Klima"
+ag_id: 14
+thema_id: 1
+kapitel_id: 4
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Auswirkungen auf das Klima
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/05-auswirkungen-wirtschaft.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/05-auswirkungen-wirtschaft.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Auswirkungen auf die Wirtschaft"
+ag_id: 14
+thema_id: 1
+kapitel_id: 5
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Auswirkungen auf die Wirtschaft
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/06-chancen-energiewende.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/06-chancen-energiewende.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Chancen für die Energiewende"
+ag_id: 14
+thema_id: 1
+kapitel_id: 6
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Chancen für die Energiewende
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/07-chancen-wohnungsmarkt.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/07-chancen-wohnungsmarkt.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Chancen für den Wohnungsmarkt"
+ag_id: 14
+thema_id: 1
+kapitel_id: 7
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Chancen für den Wohnungsmarkt
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/08-weitere-chancen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/08-weitere-chancen.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Weitere Chancen einer Ernährungsreform"
+ag_id: 14
+thema_id: 1
+kapitel_id: 8
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Weitere Chancen einer Ernährungsreform
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/Q-fragen-antworten.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/Q-fragen-antworten.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Fragen & Antworten zur Umsetzung"
+ag_id: 14
+thema_id: 1
+kapitel_id: 'Q'
+---
+
+# Warum eine Ernährungsreform notwendig ist
+
+## Fragen & Antworten zur Umsetzung
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/index.html
@@ -1,3 +1,0 @@
-<h1>Warum eine Ernaehrungsreform notwendig ist</h1>
-<p>AG 13</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/00-begriffsklaerungen-erweiterungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/00-begriffsklaerungen-erweiterungen.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Begriffsklärungen und Erweiterungen"
+ag_id: 11
+thema_id: 1
+kapitel_id: 0
+---
+
+# Aktive Neutralität
+
+## Begriffsklärungen und Erweiterungen
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/01-grundprinzipien-aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/01-grundprinzipien-aktive-neutralitaet.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Grundprinzipien der Aktiven Neutralität"
+ag_id: 11
+thema_id: 1
+kapitel_id: 1
+---
+
+# Aktive Neutralität
+
+## Grundprinzipien der Aktiven Neutralität
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/02-gleichnis-aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/02-gleichnis-aktive-neutralitaet.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Gleichnis zur aktiven Neutralität"
+ag_id: 11
+thema_id: 1
+kapitel_id: 2
+---
+
+# Aktive Neutralität
+
+## Gleichnis zur aktiven Neutralität
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/index.html
@@ -1,3 +1,0 @@
-<h1>Aktive Neutralitaet </h1>
-<p>AG 11</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/01-grenzen-sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/01-grenzen-sicherheit.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Grenzen als Instrument der systematischen Erfassung und Sicherheit"
+ag_id: 10
+thema_id: 1
+kapitel_id: 1
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Grenzen als Instrument der systematischen Erfassung und Sicherheit
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/02-bildungs-integrationsmassnahmen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/02-bildungs-integrationsmassnahmen.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Differenzierte Bildungs- und Integrationsmaßnahmen"
+ag_id: 10
+thema_id: 1
+kapitel_id: 2
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Differenzierte Bildungs- und Integrationsmaßnahmen
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/03-unterstuetzung-integration.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/03-unterstuetzung-integration.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Soziale Unterstützung und Integration"
+ag_id: 10
+thema_id: 1
+kapitel_id: 3
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Soziale Unterstützung und Integration
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/04-asylverfahren-grenzsicherung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/04-asylverfahren-grenzsicherung.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Effektive Asylverfahren und Grenzsicherung"
+ag_id: 10
+thema_id: 1
+kapitel_id: 4
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Effektive Asylverfahren und Grenzsicherung
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/05-arbeitsmarktintegration-teilhabe.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/05-arbeitsmarktintegration-teilhabe.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Arbeitsmarktintegration und wirtschaftliche Teilhabe"
+ag_id: 10
+thema_id: 1
+kapitel_id: 5
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Arbeitsmarktintegration und wirtschaftliche Teilhabe
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/06-austausch-zusammenhalt.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/06-austausch-zusammenhalt.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Kultureller Austausch und gesellschaftlicher Zusammenhalt"
+ag_id: 10
+thema_id: 1
+kapitel_id: 6
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Kultureller Austausch und gesellschaftlicher Zusammenhalt
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/07-evaluation-expertise.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/07-evaluation-expertise.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Wissenschaftliche Evaluation und unabhängige Expertise"
+ag_id: 10
+thema_id: 1
+kapitel_id: 7
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Wissenschaftliche Evaluation und unabhängige Expertise
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/index.html
@@ -1,3 +1,0 @@
-<h1>Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes Europa</h1>
-<p>AG 10</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/z-schlusswort.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/z-schlusswort.md
@@ -1,0 +1,12 @@
+---
+layout: layout.html
+title: "Schlusswort"
+ag_id: 10
+thema_id: 1
+kapitel_id: 'z'
+---
+
+# Flüchtlings- und Integrationspolitik – Unser Konzept für ein sicheres, integriertes Europa
+
+## Schlusswort
+

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/00-einfuehrung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/00-einfuehrung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einführung"
+ag_id: 5
+thema_id: 3
+kapitel_id: 0
+---
+
+# Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen
+
+## Einführung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/01-was-wir-fordern.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/01-was-wir-fordern.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Was wir fordern"
+ag_id: 5
+thema_id: 3
+kapitel_id: 1
+---
+
+# Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen
+
+## Was wir fordern

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/02-beispiele.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/02-beispiele.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Beispiele"
+ag_id: 5
+thema_id: 3
+kapitel_id: 2
+---
+
+# Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen
+
+## Beispiele

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/03-politische-umsetzungsmoeglichkeiten.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/03-politische-umsetzungsmoeglichkeiten.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Politische Umsetzungsmöglichkeiten"
+ag_id: 5
+thema_id: 3
+kapitel_id: 3
+---
+
+# Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen
+
+## Politische Umsetzungsmöglichkeiten

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/index.html
@@ -1,3 +1,0 @@
-<h1>Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen</h1>
-<p>AG 5</p>
-<p>Thema 3</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/z-zielsetzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/z-zielsetzung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Zielsetzung"
+ag_id: 5
+thema_id: 3
+kapitel_id: 'z'
+---
+
+# Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen
+
+## Zielsetzung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/01-kernidee-funktionsweise.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/01-kernidee-funktionsweise.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Kernidee und Funktionsweise"
+ag_id: 5
+thema_id: 2
+kapitel_id: 1
+---
+
+# Reservepool für Pflegefachkräfte
+
+## Kernidee und Funktionsweise

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/02-kritikpunkte-alternativansaetze.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/02-kritikpunkte-alternativansaetze.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Berücksichtigung von Kritikpunkten und Alternativansätzen"
+ag_id: 5
+thema_id: 2
+kapitel_id: 2
+---
+
+# Reservepool für Pflegefachkräfte
+
+## Berücksichtigung von Kritikpunkten und Alternativansätzen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/03-ausblick-weitere-schritte.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/03-ausblick-weitere-schritte.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Ausblick und weitere Schritte"
+ag_id: 5
+thema_id: 2
+kapitel_id: 3
+---
+
+# Reservepool für Pflegefachkräfte
+
+## Ausblick und weitere Schritte

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/04-schlussfolgerung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/04-schlussfolgerung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Schlussfolgerung"
+ag_id: 5
+thema_id: 2
+kapitel_id: 4
+---
+
+# Reservepool für Pflegefachkräfte
+
+## Schlussfolgerung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/index.html
@@ -1,3 +1,0 @@
-<h1>Reservepool für Pflegefachkräfte</h1>
-<p>AG 5</p>
-<p>Thema 2</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/01-gesetzliche-grundlage-verpflegung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/01-gesetzliche-grundlage-verpflegung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Gesetzliche Grundlage für bedarfsgerechte Verpflegung in öffentlichen Einrichtungen"
+ag_id: 5
+thema_id: 1
+kapitel_id: 1
+---
+
+# öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen
+
+## Gesetzliche Grundlage für bedarfsgerechte Verpflegung in öffentlichen Einrichtungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/index.html
@@ -1,3 +1,0 @@
-<h1>öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen</h1>
-<p>AG 5</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/00-grundsatzposition.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/00-grundsatzposition.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Grundsatzposition"
+ag_id: 2
+thema_id: 1
+kapitel_id: 0
+---
+
+# Drogenpolitik
+
+## Grundsatzposition

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/01-kontrollierte-verschreibung-ritalin.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/01-kontrollierte-verschreibung-ritalin.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Lernen aus der kontrollierten Verschreibung: Das Beispiel Methylphenidat (Ritalin, Medikinet)"
+ag_id: 2
+thema_id: 1
+kapitel_id: 1
+---
+
+# Drogenpolitik
+
+## Lernen aus der kontrollierten Verschreibung: Das Beispiel Methylphenidat (Ritalin, Medikinet)

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/02-legalisierung-schadensminimierung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/02-legalisierung-schadensminimierung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Vergleichende Analyse: Legalisierung als Instrument der Schadensminimierung"
+ag_id: 2
+thema_id: 1
+kapitel_id: 2
+---
+
+# Drogenpolitik
+
+## Vergleichende Analyse: Legalisierung als Instrument der Schadensminimierung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/03-regulierungskonzept-psychoaktive-substanzen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/03-regulierungskonzept-psychoaktive-substanzen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Ein evidenzbasiertes Regulierungskonzept für psychoaktive Substanzen"
+ag_id: 2
+thema_id: 1
+kapitel_id: 3
+---
+
+# Drogenpolitik
+
+## Ein evidenzbasiertes Regulierungskonzept für psychoaktive Substanzen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/04-forschung-medizinische-nutzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/04-forschung-medizinische-nutzung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Förderung von Forschung und medizinischer Nutzung"
+ag_id: 2
+thema_id: 1
+kapitel_id: 4
+---
+
+# Drogenpolitik
+
+## Förderung von Forschung und medizinischer Nutzung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/05-historische-entwicklung-perspektiven.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/05-historische-entwicklung-perspektiven.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Historische Entwicklung und gesellschaftliche Perspektiven"
+ag_id: 2
+thema_id: 1
+kapitel_id: 5
+---
+
+# Drogenpolitik
+
+## Historische Entwicklung und gesellschaftliche Perspektiven

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/06-wirtschaftliche-chancen-nutzen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/06-wirtschaftliche-chancen-nutzen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Wirtschaftliche Chancen und gesellschaftlicher Nutzen"
+ag_id: 2
+thema_id: 1
+kapitel_id: 6
+---
+
+# Drogenpolitik
+
+## Wirtschaftliche Chancen und gesellschaftlicher Nutzen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/07-kontrolle-kriminalisierung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/07-kontrolle-kriminalisierung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Schlussfolgerung: Kontrolle statt Kriminalisierung"
+ag_id: 2
+thema_id: 1
+kapitel_id: 7
+---
+
+# Drogenpolitik
+
+## Schlussfolgerung: Kontrolle statt Kriminalisierung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/Q-quellen-literatur.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/Q-quellen-literatur.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Quellen und weiterführende Literatur"
+ag_id: 2
+thema_id: 1
+kapitel_id: 'Q'
+---
+
+# Drogenpolitik
+
+## Quellen und weiterführende Literatur

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/index.html
@@ -1,3 +1,0 @@
-<h1>Drogenpolitik </h1>
-<p>AG 2</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/z-analyse-bewertungsfaktoren.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/z-analyse-bewertungsfaktoren.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Detaillierte Analyse wichtiger Bewertungsfaktoren für die Schädigungspotentiale psychoaktiver Substanzen"
+ag_id: 2
+thema_id: 1
+kapitel_id: 'z'
+---
+
+# Drogenpolitik
+
+## Detaillierte Analyse wichtiger Bewertungsfaktoren für die Schädigungspotentiale psychoaktiver Substanzen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/00-einleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/00-einleitung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einleitung"
+ag_id: 4
+thema_id: 1
+kapitel_id: 0
+---
+
+# Project Drawdown
+
+## Einleitung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/01-pflanzenbasierte-ernaehrung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/01-pflanzenbasierte-ernaehrung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Förderung einer pflanzenbasierten Ernährung"
+ag_id: 4
+thema_id: 1
+kapitel_id: 1
+---
+
+# Project Drawdown
+
+## Förderung einer pflanzenbasierten Ernährung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/02-lebensmittelverschwendung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/02-lebensmittelverschwendung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Reduzierung von Lebensmittelverschwendung"
+ag_id: 4
+thema_id: 1
+kapitel_id: 2
+---
+
+# Project Drawdown
+
+## Reduzierung von Lebensmittelverschwendung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/03-waelder-moore.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/03-waelder-moore.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Schutz und Wiederherstellung von Wäldern und Mooren"
+ag_id: 4
+thema_id: 1
+kapitel_id: 3
+---
+
+# Project Drawdown
+
+## Schutz und Wiederherstellung von Wäldern und Mooren

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/04-erneuerbare-energien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/04-erneuerbare-energien.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Ausbau erneuerbarer Energien"
+ag_id: 4
+thema_id: 1
+kapitel_id: 4
+---
+
+# Project Drawdown
+
+## Ausbau erneuerbarer Energien

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/05-bildungs-familienplanungsprogramme.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/05-bildungs-familienplanungsprogramme.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Förderung von Bildungs- und Familienplanungsprogrammen"
+ag_id: 4
+thema_id: 1
+kapitel_id: 5
+---
+
+# Project Drawdown
+
+## Förderung von Bildungs- und Familienplanungsprogrammen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/06-saubere-kochtechnologien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/06-saubere-kochtechnologien.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einführung sauberer Kochtechnologien"
+ag_id: 4
+thema_id: 1
+kapitel_id: 6
+---
+
+# Project Drawdown
+
+## Einführung sauberer Kochtechnologien

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/07-landnutzungspraktiken.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/07-landnutzungspraktiken.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Verbesserte Landnutzungspraktiken"
+ag_id: 4
+thema_id: 1
+kapitel_id: 7
+---
+
+# Project Drawdown
+
+## Verbesserte Landnutzungspraktiken

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/08-methanemissionen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/08-methanemissionen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Management von Methanemissionen"
+ag_id: 4
+thema_id: 1
+kapitel_id: 8
+---
+
+# Project Drawdown
+
+## Management von Methanemissionen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/09-feuchtgebiete.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/09-feuchtgebiete.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Schutz und Wiederherstellung von Feuchtgebieten"
+ag_id: 4
+thema_id: 1
+kapitel_id: 9
+---
+
+# Project Drawdown
+
+## Schutz und Wiederherstellung von Feuchtgebieten

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/10-alternative-kaeltemittel.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/10-alternative-kaeltemittel.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einsatz alternativer Kältemittel"
+ag_id: 4
+thema_id: 1
+kapitel_id: 10
+---
+
+# Project Drawdown
+
+## Einsatz alternativer Kältemittel

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/index.html
@@ -1,3 +1,0 @@
-<h1>Project Drawdown</h1>
-<p>AG 4</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/z-schlusswort.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/z-schlusswort.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Schlusswort"
+ag_id: 4
+thema_id: 1
+kapitel_id: 'z'
+---
+
+# Project Drawdown
+
+## Schlusswort

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/zz-nachtraegliche-additionen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/zz-nachtraegliche-additionen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Nachträgliche Additionen"
+ag_id: 4
+thema_id: 1
+kapitel_id: 'zz'
+---
+
+# Project Drawdown
+
+## Nachträgliche Additionen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/a-kritik-demokratie.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/a-kritik-demokratie.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Kritik an der (direkten) Demokratie"
+ag_id: 1
+thema_id: 1
+kapitel_id: 'a'
+---
+
+# Regierungsform
+
+## Kritik an der (direkten) Demokratie

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/b-politie-ideal.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/b-politie-ideal.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Die Politie als mögliches Ideal"
+ag_id: 1
+thema_id: 1
+kapitel_id: 'b'
+---
+
+# Regierungsform
+
+## Die Politie als mögliches Ideal

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/c-abstimmungs-vertretung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/c-abstimmungs-vertretung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Abstimmungs-Vertretung"
+ag_id: 1
+thema_id: 1
+kapitel_id: 'c'
+---
+
+# Regierungsform
+
+## Abstimmungs-Vertretung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/d-erweiterte-gedanken.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/d-erweiterte-gedanken.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Erweiterte Gedanken"
+ag_id: 1
+thema_id: 1
+kapitel_id: 'd'
+---
+
+# Regierungsform
+
+## Erweiterte Gedanken

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/e-zusammenfassung-ausblick.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/e-zusammenfassung-ausblick.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Zusammenfassung und Ausblick"
+ag_id: 1
+thema_id: 1
+kapitel_id: 'e'
+---
+
+# Regierungsform
+
+## Zusammenfassung und Ausblick

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/index.html
@@ -1,3 +1,0 @@
-<h1>Regierungsform</h1>
-<p>AG 1</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/00-einleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/00-einleitung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einleitung"
+ag_id: 1
+thema_id: 3
+kapitel_id: 0
+---
+
+# Verguetungssystem fuer Amtsinhaber
+
+## Einleitung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/01-verguetungsmodell-detail.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/01-verguetungsmodell-detail.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Das Vergütungsmodell im Detail"
+ag_id: 1
+thema_id: 3
+kapitel_id: 1
+---
+
+# Verguetungssystem fuer Amtsinhaber
+
+## Das Vergütungsmodell im Detail

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/index.html
@@ -1,3 +1,0 @@
-<h1>Verguetungssystem fuer Amtsinhaber</h1>
-<p>AG 1</p>
-<p>Thema 3</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem/a-einfuehrung-approval-system.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem/a-einfuehrung-approval-system.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einführung eines Approval-Systems für Einzelpositionen"
+ag_id: 1
+thema_id: 2
+kapitel_id: 'a'
+---
+
+# Wahlsystem
+
+## Einführung eines Approval-Systems für Einzelpositionen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem/index.html
@@ -1,3 +1,0 @@
-<h1>Wahlsystem</h1>
-<p>AG 1</p>
-<p>Thema 2</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung/01-kindeswohl-grundgesetz.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung/01-kindeswohl-grundgesetz.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Religiöse Erziehung und das Kindeswohl – ein unaufgelöster Konflikt im Grundgesetz?"
+ag_id: 13
+thema_id: 1
+kapitel_id: 1
+---
+
+# Religiöse Erziehung
+
+## Religiöse Erziehung und das Kindeswohl – ein unaufgelöster Konflikt im Grundgesetz?

--- a/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung/index.html
@@ -1,3 +1,0 @@
-<h1>Religiöse Erziehung</h1>
-<p>AG 13</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/00-grundlegendes-ressourcen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/00-grundlegendes-ressourcen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Grundlegendes & Ressourcen"
+ag_id: 12
+thema_id: 1
+kapitel_id: 0
+---
+
+# Grundsatzposition
+
+## Grundlegendes & Ressourcen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/01-effektive-umsetzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/01-effektive-umsetzung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Effektive Umsetzung"
+ag_id: 12
+thema_id: 1
+kapitel_id: 1
+---
+
+# Grundsatzposition
+
+## Effektive Umsetzung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/02-weitere-massnahmen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/02-weitere-massnahmen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Weitere Maßnahmen"
+ag_id: 12
+thema_id: 1
+kapitel_id: 2
+---
+
+# Grundsatzposition
+
+## Weitere Maßnahmen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/03-abschluss.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/03-abschluss.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Abschluss"
+ag_id: 12
+thema_id: 1
+kapitel_id: 3
+---
+
+# Grundsatzposition
+
+## Abschluss

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/index.html
@@ -1,3 +1,0 @@
-<h1>Grundsatzposition</h1>
-<p>AG 12</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/00-einleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/00-einleitung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Einleitung"
+ag_id: 3
+thema_id: 1
+kapitel_id: 0
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Einleitung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/01-problemaufriss.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/01-problemaufriss.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Problemaufriss"
+ag_id: 3
+thema_id: 1
+kapitel_id: 1
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Problemaufriss

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/02-leitprinzipien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/02-leitprinzipien.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Leitprinzipien ("CCT-Rahmen")"
+ag_id: 3
+thema_id: 1
+kapitel_id: 2
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Leitprinzipien ("CCT-Rahmen")

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/03-raumplanung-standortwahl.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/03-raumplanung-standortwahl.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Raumplanung & Standortwahl"
+ag_id: 3
+thema_id: 1
+kapitel_id: 3
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Raumplanung & Standortwahl

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/04-veranstaltungsformate.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/04-veranstaltungsformate.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Veranstaltungsformate"
+ag_id: 3
+thema_id: 1
+kapitel_id: 4
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Veranstaltungsformate

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/05-gesundheits-immissionsschutz.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/05-gesundheits-immissionsschutz.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Gesundheits- & Immissionsschutz"
+ag_id: 3
+thema_id: 1
+kapitel_id: 5
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Gesundheits- & Immissionsschutz

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/06-tierrechtliche-begleitmassnahmen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/06-tierrechtliche-begleitmassnahmen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Tierrechtliche Begleitmassnahmen"
+ag_id: 3
+thema_id: 1
+kapitel_id: 6
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Tierrechtliche Begleitmassnahmen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/07-governance-recht.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/07-governance-recht.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Governance & Recht"
+ag_id: 3
+thema_id: 1
+kapitel_id: 7
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Governance & Recht

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/08-logistik-sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/08-logistik-sicherheit.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Logistik & Sicherheit"
+ag_id: 3
+thema_id: 1
+kapitel_id: 8
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Logistik & Sicherheit

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/09-aufraeum-recyclingoffensive.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/09-aufraeum-recyclingoffensive.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Aufräum- & Recyclingoffensive"
+ag_id: 3
+thema_id: 1
+kapitel_id: 9
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Aufräum- & Recyclingoffensive

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/10-wirtschaft-tourismus.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/10-wirtschaft-tourismus.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Wirtschaft & Tourismus"
+ag_id: 3
+thema_id: 1
+kapitel_id: 10
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Wirtschaft & Tourismus

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/11-kommunikation-begleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/11-kommunikation-begleitung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Kommunikation & Begleitung"
+ag_id: 3
+thema_id: 1
+kapitel_id: 11
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Kommunikation & Begleitung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/12-ausblick.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/12-ausblick.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Ausblick: Vollständiger Übergang zu emissionsfreien Lichtinszenierungen"
+ag_id: 3
+thema_id: 1
+kapitel_id: 12
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Ausblick: Vollständiger Übergang zu emissionsfreien Lichtinszenierungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/Q-kritik-antworten.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/Q-kritik-antworten.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Kritik & Antworten (FAQ)"
+ag_id: 3
+thema_id: 1
+kapitel_id: 'Q'
+---
+
+# Zentralisierte Feuerwerk-Events & Förderung alternativer Shows
+
+## Kritik & Antworten (FAQ)

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/index.html
@@ -1,3 +1,0 @@
-<h1>Zentralisierte Feuerwerk-Events & Förderung alternativer Shows</h1>
-<p>AG 3</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/01-reform-zentralisierung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/01-reform-zentralisierung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Umfassende Reform und Zentralisierung des Bildungssystems"
+ag_id: 8
+thema_id: 1
+kapitel_id: 1
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Umfassende Reform und Zentralisierung des Bildungssystems

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/02-lehrkraeftemangel-arbeitsbedingungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/02-lehrkraeftemangel-arbeitsbedingungen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Bekämpfung des Lehrkräftemangels und Verbesserung der Arbeitsbedingungen"
+ag_id: 8
+thema_id: 1
+kapitel_id: 2
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Bekämpfung des Lehrkräftemangels und Verbesserung der Arbeitsbedingungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/03-individuelle-foerderung-inklusion.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/03-individuelle-foerderung-inklusion.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Individuelle Förderung und Inklusion"
+ag_id: 8
+thema_id: 1
+kapitel_id: 3
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Individuelle Förderung und Inklusion

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/04-fruehkindliche-bildung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/04-fruehkindliche-bildung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Frühkindliche Bildung stärken"
+ag_id: 8
+thema_id: 1
+kapitel_id: 4
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Frühkindliche Bildung stärken

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/05-digitalisierung-lernumgebungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/05-digitalisierung-lernumgebungen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Digitalisierung und innovative Lernumgebungen"
+ag_id: 8
+thema_id: 1
+kapitel_id: 5
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Digitalisierung und innovative Lernumgebungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/06-soziale-gerechtigkeit-chancengleichheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/06-soziale-gerechtigkeit-chancengleichheit.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Soziale Gerechtigkeit und Chancengleichheit"
+ag_id: 8
+thema_id: 1
+kapitel_id: 6
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Soziale Gerechtigkeit und Chancengleichheit

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/07-laendlicher-raum.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/07-laendlicher-raum.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Förderung des ländlichen Raums"
+ag_id: 8
+thema_id: 1
+kapitel_id: 7
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Förderung des ländlichen Raums

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/08-alternative-bildungswege.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/08-alternative-bildungswege.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Alternative Bildungswege und innovative Ansätze"
+ag_id: 8
+thema_id: 1
+kapitel_id: 8
+---
+
+# Reform des Bildungssystems [IN UeBERARBEITUNG]
+
+## Alternative Bildungswege und innovative Ansätze

--- a/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/index.html
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Weiter-Bildung/reform-des-bildungssystems/index.html
@@ -1,3 +1,0 @@
-<h1>Reform des Bildungssystems [IN UeBERARBEITUNG]</h1>
-<p>AG 8</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Warum eine Ernaehrungsreform notwendig ist"
+---
+
+# {{ title }}
+
+AG 13
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform/index.html
@@ -1,3 +1,0 @@
-<h1>Warum eine Ernaehrungsreform notwendig ist</h1>
-<p>AG 13</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Aktive Neutralitaet "
+---
+
+# {{ title }}
+
+AG 11
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet/index.html
@@ -1,3 +1,0 @@
-<h1>Aktive Neutralitaet </h1>
-<p>AG 11</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes Europa"
+---
+
+# {{ title }}
+
+AG 10
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/index.html
@@ -1,3 +1,0 @@
-<h1>Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes Europa</h1>
-<p>AG 10</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen"
+---
+
+# {{ title }}
+
+AG 5
+
+Thema 3
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/index.html
@@ -1,3 +1,0 @@
-<h1>Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen</h1>
-<p>AG 5</p>
-<p>Thema 3</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Reservepool für Pflegefachkräfte"
+---
+
+# {{ title }}
+
+AG 5
+
+Thema 2
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/index.html
@@ -1,3 +1,0 @@
-<h1>Reservepool für Pflegefachkräfte</h1>
-<p>AG 5</p>
-<p>Thema 2</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen"
+---
+
+# {{ title }}
+
+AG 5
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/index.html
@@ -1,3 +1,0 @@
-<h1>öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen</h1>
-<p>AG 5</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Drogenpolitik "
+---
+
+# {{ title }}
+
+AG 2
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik/index.html
@@ -1,3 +1,0 @@
-<h1>Drogenpolitik </h1>
-<p>AG 2</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Project Drawdown"
+---
+
+# {{ title }}
+
+AG 4
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown/index.html
@@ -1,3 +1,0 @@
-<h1>Project Drawdown</h1>
-<p>AG 4</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Regierungsform"
+---
+
+# {{ title }}
+
+AG 1
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform/index.html
@@ -1,3 +1,0 @@
-<h1>Regierungsform</h1>
-<p>AG 1</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Verguetungssystem fuer Amtsinhaber"
+---
+
+# {{ title }}
+
+AG 1
+
+Thema 3
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber/index.html
@@ -1,3 +1,0 @@
-<h1>Verguetungssystem fuer Amtsinhaber</h1>
-<p>AG 1</p>
-<p>Thema 3</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Wahlsystem"
+---
+
+# {{ title }}
+
+AG 1
+
+Thema 2
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem/index.html
@@ -1,3 +1,0 @@
-<h1>Wahlsystem</h1>
-<p>AG 1</p>
-<p>Thema 2</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Religiöse Erziehung"
+---
+
+# {{ title }}
+
+AG 13
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung/index.html
@@ -1,3 +1,0 @@
-<h1>Religiöse Erziehung</h1>
-<p>AG 13</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Grundsatzposition"
+---
+
+# {{ title }}
+
+AG 12
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition/index.html
@@ -1,3 +1,0 @@
-<h1>Grundsatzposition</h1>
-<p>AG 12</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"
+---
+
+# {{ title }}
+
+AG 3
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events/index.html
@@ -1,3 +1,0 @@
-<h1>Zentralisierte Feuerwerk-Events & Förderung alternativer Shows</h1>
-<p>AG 3</p>
-<p>Thema 1</p>

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems.md
@@ -1,0 +1,11 @@
+---
+layout: layout.html
+title: "Reform des Bildungssystems [IN UeBERARBEITUNG]"
+---
+
+# {{ title }}
+
+AG 8
+
+Thema 1
+

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems/index.html
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Weiter-Bildung/reform-des-bildungssystems/index.html
@@ -1,3 +1,0 @@
-<h1>Reform des Bildungssystems [IN UeBERARBEITUNG]</h1>
-<p>AG 8</p>
-<p>Thema 1</p>


### PR DESCRIPTION
## Summary
- replace long program `index.html` placeholders with per-chapter Markdown files
- add Eleventy front matter including `ag_id`, `thema_id`, and `kapitel_id`
- remove obsolete HTML stubs under `src/de/Programm/lang`

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_6893642485f8833382e9372c0a40d7aa