### PR TITLE
AKSEP: add lang aggregation script

### DIFF
--- a/projects/AKSEP/package-lock.json
+++ b/projects/AKSEP/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "aksep-site",
       "devDependencies": {
-        "@11ty/eleventy": "^2.0.0"
+        "@11ty/eleventy": "^2.0.0",
+        "gray-matter": "^4.0.3"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/projects/AKSEP/package.json
+++ b/projects/AKSEP/package.json
@@ -3,9 +3,11 @@
   "private": true,
   "scripts": {
     "build": "eleventy",
-    "serve": "eleventy --serve"
+    "serve": "eleventy --serve",
+    "aggregate-lang": "node scripts/aggregate-lang.js"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^2.0.0"
+    "@11ty/eleventy": "^2.0.0",
+    "gray-matter": "^4.0.3"
   }
 }

--- a/projects/AKSEP/scripts/aggregate-lang.js
+++ b/projects/AKSEP/scripts/aggregate-lang.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const baseDir = path.join(__dirname, '..', 'src/de/Programm/lang');
+
+function aggregate() {
+  const agDirs = fs.readdirSync(baseDir, { withFileTypes: true }).filter(d => d.isDirectory());
+  agDirs.forEach(agDir => {
+    const agPath = path.join(baseDir, agDir.name);
+    const entries = fs.readdirSync(agPath, { withFileTypes: true });
+    entries.forEach(entry => {
+      if (!entry.isDirectory()) return;
+      const themeDir = path.join(agPath, entry.name);
+      const chapterFiles = fs.readdirSync(themeDir).filter(f => f.endsWith('.md'));
+      if (!chapterFiles.length) return;
+      const chapters = chapterFiles.map(file => {
+        const fullPath = path.join(themeDir, file);
+        const src = fs.readFileSync(fullPath, 'utf8');
+        const { data, content } = matter(src);
+        return { data, content };
+      }).sort((a, b) => a.data.kapitel_id - b.data.kapitel_id);
+      const meta = chapters[0].data;
+      const chapterContent = chapters.map(ch => {
+        let body = ch.content.trim();
+        if (body.startsWith('##')) {
+          const lines = body.split('\n');
+          lines.shift();
+          body = lines.join('\n').trim();
+        }
+        return `## ${ch.data.kapitel}\n${body}`;
+      }).join('\n\n');
+      const full = matter.stringify(`# ${meta.thema}\n\n${chapterContent}\n`, {
+        layout: 'layout.html',
+        ag: meta.ag,
+        ag_id: meta.ag_id,
+        thema: meta.thema,
+        thema_id: meta.thema_id,
+        tags: [meta.thema]
+      });
+      const outFile = path.join(agPath, `${entry.name}.md`);
+      fs.writeFileSync(outFile, full);
+      console.log(`Generated ${path.relative(baseDir, outFile)} from ${chapterFiles.length} chapters.`);
+    });
+  });
+}
+
+aggregate();


### PR DESCRIPTION
## Summary
- add gray-matter-based aggregation script to combine chapter markdown files into single theme file
- expose aggregator via npm script

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a330a7808333b2b3ad1a3cf9b217