### PR TITLE
[AKSEP]: add language metadata

### DIFF
--- a/projects/AKSEP/src/datenschutz.html
+++ b/projects/AKSEP/src/datenschutz.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Datenschutz</title>
-  </head>
-  <body>
-    <h1>Datenschutz</h1>
-    <p>Diese Seite dient als Platzhalter.</p>
-  </body>
-</html>
+---
+layout: layout.njk
+lang: de
+title: Datenschutz
+---
+<h1>Datenschutz</h1>
+<p>Diese Seite dient als Platzhalter.</p>

--- a/projects/AKSEP/src/de/Begriffe/AG/index.html
+++ b/projects/AKSEP/src/de/Begriffe/AG/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>AG (Arbeitsgruppe)</h1>

--- a/projects/AKSEP/src/de/Begriffe/Cancel-Culture/index.html
+++ b/projects/AKSEP/src/de/Begriffe/Cancel-Culture/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Cancel Culture</h1>

--- a/projects/AKSEP/src/de/Begriffe/Demokratie/index.html
+++ b/projects/AKSEP/src/de/Begriffe/Demokratie/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Demokratie</h1>

--- a/projects/AKSEP/src/de/Begriffe/Extremismus/index.html
+++ b/projects/AKSEP/src/de/Begriffe/Extremismus/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Extremismus</h1>

--- a/projects/AKSEP/src/de/Begriffe/Identitaetspolitik/index.html
+++ b/projects/AKSEP/src/de/Begriffe/Identitaetspolitik/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Identitätspolitik</h1>

--- a/projects/AKSEP/src/de/Begriffe/faschismus/index.html
+++ b/projects/AKSEP/src/de/Begriffe/faschismus/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Faschismus</h1>

--- a/projects/AKSEP/src/de/Begriffe/index.html
+++ b/projects/AKSEP/src/de/Begriffe/index.html
@@ -1,3 +1,8 @@
+---
+layout: layout.njk
+lang: de
+title: Begriffsverzeichnis
+---
 <h1>Begriffsverzeichnis</h1>
 <ul>
   <!-- optional: list of available Begriff links -->

--- a/projects/AKSEP/src/de/Begriffe/liberalismus/index.html
+++ b/projects/AKSEP/src/de/Begriffe/liberalismus/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Liberalismus</h1>

--- a/projects/AKSEP/src/de/Begriffe/meinungsfreiheit/index.html
+++ b/projects/AKSEP/src/de/Begriffe/meinungsfreiheit/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Meinungsfreiheit</h1>

--- a/projects/AKSEP/src/de/Begriffe/nationalsozialismus/index.html
+++ b/projects/AKSEP/src/de/Begriffe/nationalsozialismus/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Nationalsozialismus</h1>

--- a/projects/AKSEP/src/de/Begriffe/neoliberalismus/index.html
+++ b/projects/AKSEP/src/de/Begriffe/neoliberalismus/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Neoliberalismus</h1>

--- a/projects/AKSEP/src/de/Begriffe/paedophil-paedokriminell/index.html
+++ b/projects/AKSEP/src/de/Begriffe/paedophil-paedokriminell/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>pädophil vs. pädokriminell</h1>

--- a/projects/AKSEP/src/de/Begriffe/populismus/index.html
+++ b/projects/AKSEP/src/de/Begriffe/populismus/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Populismus</h1>

--- a/projects/AKSEP/src/de/Begriffe/radikal/index.html
+++ b/projects/AKSEP/src/de/Begriffe/radikal/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>radikal</h1>

--- a/projects/AKSEP/src/de/Begriffe/rechts-links/index.html
+++ b/projects/AKSEP/src/de/Begriffe/rechts-links/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Rechts vs. Links (politisch)</h1>

--- a/projects/AKSEP/src/de/Begriffe/toleranz/index.html
+++ b/projects/AKSEP/src/de/Begriffe/toleranz/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Toleranz</h1>

--- a/projects/AKSEP/src/de/Begriffe/wokeness/index.html
+++ b/projects/AKSEP/src/de/Begriffe/wokeness/index.html
@@ -1,4 +1,5 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <h1>Wokeness</h1>

--- a/projects/AKSEP/src/de/Finanzen-Transparenz/index.html
+++ b/projects/AKSEP/src/de/Finanzen-Transparenz/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Finanzen und Transparenz
+---

--- a/projects/AKSEP/src/de/Kontact/index.html
+++ b/projects/AKSEP/src/de/Kontact/index.html
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <!-- Layout: layout.njk (can be overridden later) -->
 <h1>Kontakt</h1>

--- a/projects/AKSEP/src/de/Mitglied-werden/index.html
+++ b/projects/AKSEP/src/de/Mitglied-werden/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Mitglied werden
+---

--- a/projects/AKSEP/src/de/Partner-Projekte/index.html
+++ b/projects/AKSEP/src/de/Partner-Projekte/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Partner Projekte
+---

--- a/projects/AKSEP/src/de/Praeambel/index.html
+++ b/projects/AKSEP/src/de/Praeambel/index.html
@@ -1,1 +1,5 @@
-Inhalt Präambel
+---
+layout: layout.njk
+lang: de
+title: Praeambel
+---

--- a/projects/AKSEP/src/de/Presse/index.html
+++ b/projects/AKSEP/src/de/Presse/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Presse
+---

--- a/projects/AKSEP/src/de/Programm-google-docs.html
+++ b/projects/AKSEP/src/de/Programm-google-docs.html
@@ -1,3 +1,7 @@
+---
+layout: null
+lang: de
+---
 <!DOCTYPE html>
 <html>
 <head>

--- a/projects/AKSEP/src/de/Programm/index.html
+++ b/projects/AKSEP/src/de/Programm/index.html
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <!-- Layout: layout.njk (can be overridden later) -->
 <h1>Programm-Überblick</h1>

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Agrarpolitik.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Agrarpolitik"
 ag_id: 14
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Aussenpolitik.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Aussenpolitik"
 ag_id: 11
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Bildung.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Bildung.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Bildung"
 ag_id: 8
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Europa-und-Migration.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Europa und Migration"
 ag_id: 10
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Forschung-und-KI.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Forschung und KI"
 ag_id: 6
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Gesundheit.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Gesundheit"
 ag_id: 5
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Innere-Sicherheit.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Klimaschutz.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Regierung.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Regierung.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Sonstiges.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "'AG' Sonstiges"
 ag_id: 13
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Soziales.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Soziales.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Soziales"
 ag_id: 9
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Tierrechte.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Tierrechte"
 ag_id: 12
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Umweltschutz.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 tags: []

--- a/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft.md
+++ b/projects/AKSEP/src/de/Programm/kurz/AG-Wirtschaft.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Wirtschaft"
 ag_id: 7
 tags: []

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/01-tierrechte.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/01-tierrechte.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/02-gesundheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/02-gesundheit.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/03-natur-umwelt.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/03-natur-umwelt.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/04-klima.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/04-klima.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/05-wirtschaft.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/05-wirtschaft.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/06-energiewende.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/06-energiewende.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/07-wohnungsmarkt.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/07-wohnungsmarkt.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/08-weitere-chancen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/08-weitere-chancen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/Q-fragen-antworten.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Agrarpolitik/ernaehrungsreform/Q-fragen-antworten.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Agrarpolitik
 ag_id: 14
 thema: Warum eine Ernaehrungsreform notwendig ist

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Aussenpolitik
 ag_id: 11
 thema: 'Aktive Neutralitaet '

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/00-begriffsklaerungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/00-begriffsklaerungen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Aussenpolitik
 ag_id: 11
 thema: 'Aktive Neutralitaet '

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/01-grundprinzipien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/01-grundprinzipien.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Aussenpolitik
 ag_id: 11
 thema: 'Aktive Neutralitaet '

--- a/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/02-gleichnis-aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Aussenpolitik/aktive-neutralitaet/02-gleichnis-aktive-neutralitaet.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Aussenpolitik
 ag_id: 11
 thema: 'Aktive Neutralitaet '

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: 'Reform des Bildungssystems [IN UeBERARBEITUNG]'

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/01-reform-zentralisierung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/01-reform-zentralisierung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/02-lehrkraeftemangel-arbeitsbedingungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/02-lehrkraeftemangel-arbeitsbedingungen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/03-individuelle-foerderung-inklusion.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/03-individuelle-foerderung-inklusion.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/04-fruehkindliche-bildung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/04-fruehkindliche-bildung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/05-digitalisierung-lernumgebungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/05-digitalisierung-lernumgebungen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/06-soziale-gerechtigkeit-chancengleichheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/06-soziale-gerechtigkeit-chancengleichheit.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/07-laendlicher-raum.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/07-laendlicher-raum.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/08-alternative-bildungswege.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Bildung/reform-des-bildungssystems/08-alternative-bildungswege.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Bildung
 ag_id: 8
 thema: Reform des Bildungssystems [IN UeBERARBEITUNG]

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: >-

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/01-grenzen-sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/01-grenzen-sicherheit.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/02-bildungs-integration.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/02-bildungs-integration.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/03-soziale-unterstuetzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/03-soziale-unterstuetzung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/04-asylverfahren-grenzsicherung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/04-asylverfahren-grenzsicherung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/05-arbeitsmarkt-teilhabe.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/05-arbeitsmarkt-teilhabe.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/06-austausch-zusammenhalt.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/06-austausch-zusammenhalt.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/07-evaluation-expertise.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/07-evaluation-expertise.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/z-schlusswort.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik/z-schlusswort.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Europa und Migration
 ag_id: 10
 thema: Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/00-einfuehrung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/00-einfuehrung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/01-was-wir-fordern.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/01-was-wir-fordern.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/02-beispiele.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/02-beispiele.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/03-politische-umsetzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/03-politische-umsetzung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/z-zielsetzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen/z-zielsetzung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Reservepool für Pflegefachkräfte

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/01-kernidee.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/01-kernidee.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Reservepool für Pflegefachkräfte

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/02-kritik.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/02-kritik.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Reservepool für Pflegefachkräfte

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/03-ausblick.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/03-ausblick.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Reservepool für Pflegefachkräfte

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/04-schlussfolgerung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/reservepool-fuer-pflegefachkraefte/04-schlussfolgerung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: Reservepool für Pflegefachkräfte

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/01-gesetzliche-grundlage-verpflegung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen/01-gesetzliche-grundlage-verpflegung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: AG Gesundheit
 ag_id: 5
 thema: öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Innere Sicherheit
 ag_id: 2
 thema: 'Drogenpolitik '

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/00-grundsatzposition.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/00-grundsatzposition.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/01-lernen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/01-lernen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/02-vergleichende-analyse.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/02-vergleichende-analyse.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/03-evidenzbasiertes-regulierungskonzept.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/03-evidenzbasiertes-regulierungskonzept.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/04-forschung-medizin.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/04-forschung-medizin.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/05-historische-entwicklung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/05-historische-entwicklung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/06-chancen-nutzen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/06-chancen-nutzen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/07-kontrolle-statt-kriminalisierung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/07-kontrolle-statt-kriminalisierung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/Q-quellen-literatur.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/Q-quellen-literatur.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/z-analyse-bewertungsfaktoren.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Innere-Sicherheit/drogenpolitik/z-analyse-bewertungsfaktoren.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Klimaschutz
 ag_id: 4
 thema: Project Drawdown

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/00-einleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/00-einleitung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/01-pflanzenbasiert.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/01-pflanzenbasiert.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/02-lebensmittelverschwendung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/02-lebensmittelverschwendung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/03-waelder-moore.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/03-waelder-moore.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/04-erneuerbare-energien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/04-erneuerbare-energien.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/05-bildung-familienplanung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/05-bildung-familienplanung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/06-saubere-kochtechnologien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/06-saubere-kochtechnologien.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/07-landnutzungspraktiken.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/07-landnutzungspraktiken.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/08-methanemissionen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/08-methanemissionen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/09-feuchtgebiete.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/09-feuchtgebiete.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/10-alternative-kaeltemittel.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/10-alternative-kaeltemittel.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/z-schlusswort.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/z-schlusswort.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/zz-nachtraegliche-additionen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Klimaschutz/project-drawdown/zz-nachtraegliche-additionen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Regierung
 ag_id: 1
 thema: Regierungsform

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/a-kritik-demokratie.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/a-kritik-demokratie.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Regierungsform"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/b-politie-ideal.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/b-politie-ideal.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Regierungsform"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/c-abstimmungs-vertretung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/c-abstimmungs-vertretung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Regierungsform"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/d-erweiterte-gedanken.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/d-erweiterte-gedanken.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Regierungsform"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/e-zusammenfassung-ausblick.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/regierungsform/e-zusammenfassung-ausblick.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Regierungsform"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Regierung
 ag_id: 1
 thema: Verguetungssystem fuer Amtsinhaber

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/00-einleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/00-einleitung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Verguetungssystem fuer Amtsinhaber"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/01-im-detail.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/verguetungssystem-fuer-amtsinhaber/01-im-detail.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Verguetungssystem fuer Amtsinhaber"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Regierung
 ag_id: 1
 thema: Wahlsystem

--- a/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem/a-approval-system.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Regierung/wahlsystem/a-approval-system.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Wahlsystem"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: '''AG'' Sonstiges'
 ag_id: 13
 thema: Religiöse Erziehung

--- a/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung/01-kindeswohl-grundgesetz.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Sonstiges/religioese-erziehung/01-kindeswohl-grundgesetz.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "'AG' Sonstiges"
 ag_id: 13
 thema: "Religiöse Erziehung"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Tierrechte
 ag_id: 12
 thema: Grundsatzposition

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/00-grundlegendes-ressourcen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/00-grundlegendes-ressourcen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Tierrechte"
 ag_id: 12
 thema: "Grundsatzposition"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/01-effektive-umsetzung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/01-effektive-umsetzung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Tierrechte"
 ag_id: 12
 thema: "Grundsatzposition"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/02-weitere-massnahmen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/02-weitere-massnahmen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Tierrechte"
 ag_id: 12
 thema: "Grundsatzposition"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/03-abschluss.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Tierrechte/grundsatzposition/03-abschluss.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Tierrechte"
 ag_id: 12
 thema: "Grundsatzposition"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: AG Umweltschutz
 ag_id: 3
 thema: Zentralisierte Feuerwerk-Events & Förderung alternativer Shows

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/00-einleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/00-einleitung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/01-problemaufriss.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/01-problemaufriss.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/02-leitprinzipien.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/02-leitprinzipien.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/03-raumplanung-standortwahl.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/03-raumplanung-standortwahl.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/04-veranstaltungsformate.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/04-veranstaltungsformate.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/05-gesundheits-immissionsschutz.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/05-gesundheits-immissionsschutz.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/06-tierrechtliche-begleitmassnahmen.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/06-tierrechtliche-begleitmassnahmen.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/07-governance-recht.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/07-governance-recht.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/08-logistik-sicherheit.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/08-logistik-sicherheit.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/09-aufraeum-recyclingoffensive.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/09-aufraeum-recyclingoffensive.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/10-wirtschaft-tourismus.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/10-wirtschaft-tourismus.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/11-kommunikation-begleitung.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/11-kommunikation-begleitung.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/12-ausblick.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/12-ausblick.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/Q-kritik-antworten.md
+++ b/projects/AKSEP/src/de/Programm/lang/AG-Umweltschutz/zentralisierte-feuerwerk-events/Q-kritik-antworten.md
@@ -1,5 +1,6 @@
 ---
 layout: null
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Agrarpolitik/ernaehrungsreform.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Agrarpolitik"
 ag_id: 14
 thema: "Warum eine Ernaehrungsreform notwendig ist"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Aussenpolitik/aktive-neutralitaet.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Aussenpolitik"
 ag_id: 11
 thema: "Aktive Neutralitaet "

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Bildung/reform-des-bildungssystems.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Bildung/reform-des-bildungssystems.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Bildung"
 ag_id: 8
 thema: "Reform des Bildungssystems [IN UeBERARBEITUNG]"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Europa-und-Migration/fluechtlings-und-integrationspolitik.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Europa und Migration"
 ag_id: 10
 thema: "Fluechtlings- und Integrationspolitik – Unser Konzept fuer ein sicheres, integriertes Europa"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/re-evaluation-von-ernaehrungsempfehlungen.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Gesundheit"
 ag_id: 5
 thema: "Wissenschaftlich fundierte Re-Evalutation offizieller Ernährungsempfehlungen"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/reservepool-fuer-pflegefachkraefte.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Gesundheit"
 ag_id: 5
 thema: "Reservepool für Pflegefachkräfte"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Gesundheit/verpflegung-in-versorgungseinrichtungen.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Gesundheit"
 ag_id: 5
 thema: "öffentliche oder gemeinschaftlich genutzte Versorgungseinrichtungen"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Innere-Sicherheit/drogenpolitik.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Innere Sicherheit"
 ag_id: 2
 thema: "Drogenpolitik "

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Klimaschutz/project-drawdown.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Klimaschutz"
 ag_id: 4
 thema: "Project Drawdown"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/regierungsform.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Regierungsform"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/verguetungssystem-fuer-amtsinhaber.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Verguetungssystem fuer Amtsinhaber"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Regierung/wahlsystem.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Regierung"
 ag_id: 1
 thema: "Wahlsystem"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Sonstiges/religioese-erziehung.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "'AG' Sonstiges"
 ag_id: 13
 thema: "Religiöse Erziehung"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Tierrechte/grundsatzposition.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Tierrechte"
 ag_id: 12
 thema: "Grundsatzposition"

--- a/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
+++ b/projects/AKSEP/src/de/Programm/mittel/AG-Umweltschutz/zentralisierte-feuerwerk-events.md
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ag: "AG Umweltschutz"
 ag_id: 3
 thema: "Zentralisierte Feuerwerk-Events & Förderung alternativer Shows"

--- a/projects/AKSEP/src/de/Projekte/index.html
+++ b/projects/AKSEP/src/de/Projekte/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Projekte
+---

--- a/projects/AKSEP/src/de/Satzung/index.html
+++ b/projects/AKSEP/src/de/Satzung/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Satzung
+---

--- a/projects/AKSEP/src/de/Termine/index.html
+++ b/projects/AKSEP/src/de/Termine/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Termine
+---

--- a/projects/AKSEP/src/de/index.html
+++ b/projects/AKSEP/src/de/index.html
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <!-- Layout: layout.njk (can be overridden later) -->
 <h1>Willkommen</h1>

--- a/projects/AKSEP/src/de/ueber-uns/Geschichte/index.html
+++ b/projects/AKSEP/src/de/ueber-uns/Geschichte/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Geschichte
+---

--- a/projects/AKSEP/src/de/ueber-uns/Personen/index.html
+++ b/projects/AKSEP/src/de/ueber-uns/Personen/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Personen
+---

--- a/projects/AKSEP/src/de/ueber-uns/index.html
+++ b/projects/AKSEP/src/de/ueber-uns/index.html
@@ -1,5 +1,6 @@
 ---
 layout: layout.njk
+lang: de
 ---
 <!-- Layout: layout.njk (can be overridden later) -->
 <h1>Über uns</h1>

--- a/projects/AKSEP/src/de/unterstuetzen/index.html
+++ b/projects/AKSEP/src/de/unterstuetzen/index.html
@@ -1,0 +1,5 @@
+---
+layout: layout.njk
+lang: de
+title: Unterstuetzen
+---

--- a/projects/AKSEP/src/impressum.html
+++ b/projects/AKSEP/src/impressum.html
@@ -1,15 +1,7 @@
-<!DOCTYPE html>
-<html lang="de">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Impressum</title>
-  </head>
-  <body>
-    <h1>Impressum</h1>
-    <p>
-      Diese Seite dient als Platzhalter.
-      Sandstraße 119, 64319 Pfungstadt, Germany
-    </p>
-  </body>
-</html>
+---
+layout: layout.njk
+lang: de
+title: Impressum
+---
+<h1>Impressum</h1>
+<p>Diese Seite dient als Platzhalter. Sandstraße 119, 64319 Pfungstadt, Germany</p>

--- a/projects/AKSEP/src/index.html
+++ b/projects/AKSEP/src/index.html
@@ -1,5 +1,9 @@
+---
+lang: de
+layout: null
+---
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
   <head>
     <meta http-equiv="refresh" content="0; url=./de/" />
     <title>Redirecting...</title>

--- a/projects/AKSEP/src/templates/layout.njk
+++ b/projects/AKSEP/src/templates/layout.njk
@@ -2,7 +2,7 @@
 templateEngineOverride: njk
 ---
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang | default('de') }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- Convert standalone HTML pages to Eleventy templates and set `lang: de` front matter.
- Add `lang: de` metadata to remaining program chapters and placeholders so layout can apply the language attribute.

## Testing
- `npm run lint` (fails: Missing script)
- `npm test` (fails: Missing script)
- `npm run build` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_6894ea8762e88333b3064c00b810cdac