### PR TITLE
[AKSEP]: Refactor header into partial and relocate start page

### DIFF
--- a/projects/AKSEP/src/index.html
+++ b/projects/AKSEP/src/index.html
@@ -1,10 +1,11 @@
 ---
-layout: layout.njk
-lang: de
+layout: null
+permalink: /
+eleventyExcludeFromCollections: true
 ---
-<!-- Layout: layout.njk (can be overridden later) -->
-<h1>Willkommen</h1>
-<p>Dieses Programm ist das Ergebnis einer intensiven Zusammenarbeit innerhalb des AKSEP-Vorstands. Ziel des Dokuments ist es, Ideen und Vorschläge zu sammeln, die als Grundlage unserer politischen Initiative dienen. In vielen Diskussionen wurden erste Visionen festgehalten, die laufend überarbeitet und erweitert werden, um sie zu einem tragfähigen Konzept zu formen.</p>
-<p>Wir wollen aktivistische Ansätze mit konkreter politischer Teilhabe verbinden. Auf unserem Discord-Server stellen wir umfangreiche Ressourcen bereit, diskutieren Fragen aus allen Bereichen und unterstützen Bewegungen, die friedlich auf Missstände aufmerksam machen. So erreichen wir Menschen außerhalb klassischer politischer Kanäle und schaffen ein Bewusstsein für Themen, die im Alltag oft übersehen werden.</p>
-<p>Besonderes Gewicht legen wir auf den Klimaschutz. Der Klimawandel bedroht unsere Lebensgrundlagen und macht entschlossene Maßnahmen notwendig. Viele dieser Maßnahmen bringen wirtschaftliche Chancen mit sich, etwa indem Flächen dank einer pflanzenbasierten Ernährung frei werden und für Aufforstung oder erneuerbare Energien genutzt werden können. Wir wollen diese Potenziale nutzen und dabei soziale Gerechtigkeit fördern.</p>
-<p>Das Dokument versteht sich als lebendiger Entwurf. Wir passen Inhalte stetig an, sobald neue Erkenntnisse und Rückmeldungen vorliegen. Jede Arbeitsgemeinschaft vertieft spezifische Themen und erarbeitet praxisnahe Konzepte. So entsteht Schritt für Schritt ein Programm, das den aktuellen Herausforderungen gerecht wird und flexible Lösungsansätze bietet.</p>
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta http-equiv="refresh" content="0; url=/start/">
+  </head>
+</html>

--- a/projects/AKSEP/src/start/index.html
+++ b/projects/AKSEP/src/start/index.html
@@ -1,0 +1,10 @@
+---
+layout: layout.njk
+lang: de
+---
+<!-- Layout: layout.njk (can be overridden later) -->
+<h1>Willkommen</h1>
+<p>Dieses Programm ist das Ergebnis einer intensiven Zusammenarbeit innerhalb des AKSEP-Vorstands. Ziel des Dokuments ist es, Ideen und Vorschläge zu sammeln, die als Grundlage unserer politischen Initiative dienen. In vielen Diskussionen wurden erste Visionen festgehalten, die laufend überarbeitet und erweitert werden, um sie zu einem tragfähigen Konzept zu formen.</p>
+<p>Wir wollen aktivistische Ansätze mit konkreter politischer Teilhabe verbinden. Auf unserem Discord-Server stellen wir umfangreiche Ressourcen bereit, diskutieren Fragen aus allen Bereichen und unterstützen Bewegungen, die friedlich auf Missstände aufmerksam machen. So erreichen wir Menschen außerhalb klassischer politischer Kanäle und schaffen ein Bewusstsein für Themen, die im Alltag oft übersehen werden.</p>
+<p>Besonderes Gewicht legen wir auf den Klimaschutz. Der Klimawandel bedroht unsere Lebensgrundlagen und macht entschlossene Maßnahmen notwendig. Viele dieser Maßnahmen bringen wirtschaftliche Chancen mit sich, etwa indem Flächen dank einer pflanzenbasierten Ernährung frei werden und für Aufforstung oder erneuerbare Energien genutzt werden können. Wir wollen diese Potenziale nutzen und dabei soziale Gerechtigkeit fördern.</p>
+<p>Das Dokument versteht sich als lebendiger Entwurf. Wir passen Inhalte stetig an, sobald neue Erkenntnisse und Rückmeldungen vorliegen. Jede Arbeitsgemeinschaft vertieft spezifische Themen und erarbeitet praxisnahe Konzepte. So entsteht Schritt für Schritt ein Programm, das den aktuellen Herausforderungen gerecht wird und flexible Lösungsansätze bietet.</p>

--- a/projects/AKSEP/src/templates/header.njk
+++ b/projects/AKSEP/src/templates/header.njk
@@ -1,20 +1,15 @@
----
-templateEngineOverride: njk
----
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ title }}</title>
-    <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
-    <link rel="stylesheet" href="{{ '/assets/css/variables.css' | url }}">
-  </head>
-  <body>
-    {% include 'header.njk' %}
-    <main>
-      {{ content | safe }}
-    </main>
-    {% include 'footer.njk' %}
-  </body>
-</html>
+<header>
+  <nav>
+    <ul>
+      <li><a href="/start/">Start</a></li>
+      <li><a href="/Programm/">Programm</a></li>
+      <li><a href="/Projekte/">Projekte</a></li>
+      <li><a href="/Termine/">Termine</a></li>
+      <li><a href="/ueber-uns/">Über uns</a></li>
+      <li><a href="/unterstuetzen/">Unterstützen</a></li>
+      <li><a href="/Presse/">Presse</a></li>
+      <li><a href="/Mitglied-werden/">Mitglied werden</a></li>
+      <li><a href="/Kontact/">Kontakt</a></li>
+    </ul>
+  </nav>
+</header>


### PR DESCRIPTION
## Summary
- simplify header.njk into a minimal partial with standard navigation links
- move former index.html to /start/ and add redirecting root index

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_6895b02224648333a020313623f19f5e