### PR TITLE
[AKSEP]: add pinia and test setup

### DIFF
--- a/projects/AKSEP/.eslintrc.cjs
+++ b/projects/AKSEP/.eslintrc.cjs
@@ -1,3 +1,8 @@
 module.exports = {
-  extends: ['@nuxtjs/eslint-config-typescript']
+  extends: ['@nuxtjs/eslint-config-typescript'],
+  globals: {
+    describe: 'readonly',
+    it: 'readonly',
+    expect: 'readonly'
+  }
 }

--- a/projects/AKSEP/README.md
+++ b/projects/AKSEP/README.md
@@ -22,6 +22,12 @@ Der Befehl startet einen lokalen Server unter http://localhost:3000.
 npm run lint
 ```
 
+## Tests
+```bash
+npm test
+```
+Der Test prueft, ob die Startseite gerendert werden kann.
+
 ## Produktion builden
 ```bash
 npm run build

--- a/projects/AKSEP/docs/TO-DO.md
+++ b/projects/AKSEP/docs/TO-DO.md
@@ -1,0 +1,7 @@
+# Offene Aufgaben
+
+- Module in `modules/` implementieren (`content-aliases.ts`, `content-edited-git.ts`, `content-ensure.ts`, `glossary-autolink.ts`).
+- Skripte in `scripts/` vervollstaendigen (z.B. `build-chapters-toc.mjs`).
+- Komponenten wie `AppHeader.vue` mit Inhalt fuellen.
+- `src/stores/prefs.ts` fertigstellen.
+- Uebersetzungsdateien um reale Texte erweitern.

--- a/projects/AKSEP/i18n.config.ts
+++ b/projects/AKSEP/i18n.config.ts
@@ -1,8 +1,3 @@
 export default defineI18nConfig(() => ({
-  legacy: false,
-  locale: 'de',
-  messages: {
-    de: {},
-    en: {}
-  }
+  legacy: false
 }))

--- a/projects/AKSEP/nuxt.config.ts
+++ b/projects/AKSEP/nuxt.config.ts
@@ -1,3 +1,12 @@
 export default defineNuxtConfig({
-  modules: ['@nuxt/content', '@nuxtjs/i18n']
+  modules: ['@nuxt/content', '@nuxtjs/i18n', '@pinia/nuxt'],
+  i18n: {
+    locales: [
+      { code: 'de', file: 'de.json' },
+      { code: 'en', file: 'en.json' }
+    ],
+    defaultLocale: 'de',
+    langDir: 'src/locales',
+    vueI18n: './i18n.config.ts'
+  }
 })

--- a/projects/AKSEP/package.json
+++ b/projects/AKSEP/package.json
@@ -5,16 +5,22 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "lint": "eslint .",
-    "start": "nuxt start"
+    "start": "nuxt start",
+    "test": "vitest"
   },
   "dependencies": {
     "@nuxt/content": "^2.8.0",
     "@nuxtjs/i18n": "^8.0.0",
-    "nuxt": "^3.12.1"
+    "@pinia/nuxt": "^0.11.2",
+    "nuxt": "^3.12.1",
+    "pinia": "^3.0.3"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@tsconfig/nuxt": "^2.0.3",
-    "eslint": "^8.56.0"
+    "@nuxt/test-utils": "^3.19.2",
+    "eslint": "^8.56.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/projects/AKSEP/server/routes/sitemap.xml.ts
+++ b/projects/AKSEP/server/routes/sitemap.xml.ts
@@ -1,7 +1,11 @@
+import { getRequestURL } from 'h3'
 import { serverQueryContent } from '#content/server'
 
 export default defineEventHandler(async (event) => {
   const docs = await serverQueryContent(event).find()
-  const urls = docs.map(doc => `<url><loc>${doc._path}</loc></url>`).join('')
+  const base = getRequestURL(event).origin
+  const urls = docs
+    .map(doc => `<url><loc>${base}${doc._path}</loc></url>`)
+    .join('')
   return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`
 })

--- a/projects/AKSEP/src/locales/de.json
+++ b/projects/AKSEP/src/locales/de.json
@@ -1,1 +1,3 @@
-{}
+{
+  "greeting": "Hallo Welt"
+}

--- a/projects/AKSEP/src/locales/en.json
+++ b/projects/AKSEP/src/locales/en.json
@@ -1,1 +1,3 @@
-{}
+{
+  "greeting": "Hello world"
+}

--- a/projects/AKSEP/tests/preview.spec.ts
+++ b/projects/AKSEP/tests/preview.spec.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+await setup({
+  rootDir: fileURLToPath(new URL('..', import.meta.url))
+})
+
+describe('preview', () => {
+  it('renders index page', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('<div')
+  })
+})


### PR DESCRIPTION
## Summary
- add Pinia module and basic i18n strings
- fix sitemap links and document open TODOs
- add vitest-based preview test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac34d2b6a48333aaf378a061fdc703