### PR TITLE
[AKSEP]: configure nuxt project and add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+projects/AKSEP-ALT/

--- a/projects/AKSEP/docs/TO-DO.md
+++ b/projects/AKSEP/docs/TO-DO.md
@@ -1,0 +1,7 @@
+# TODO
+
+- `app.config.ts` mit echter Anwendungskonfiguration füllen.
+- Weiterleitung in `src/pages/index.vue` implementieren.
+- Übersetzungen in `i18n.config.ts` ergänzen.
+- Module in `modules/` implementieren oder entfernen, falls überflüssig.
+- Automatisierte Tests über die Grundprüfung hinaus erweitern.

--- a/projects/AKSEP/i18n.config.ts
+++ b/projects/AKSEP/i18n.config.ts
@@ -1,3 +1,5 @@
+import { defineI18nConfig } from '#i18n'
+
 export default defineI18nConfig(() => ({
   legacy: false,
   locale: 'de',

--- a/projects/AKSEP/nuxt.config.ts
+++ b/projects/AKSEP/nuxt.config.ts
@@ -1,3 +1,9 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
 export default defineNuxtConfig({
-  modules: ['@nuxt/content', '@nuxtjs/i18n']
+  srcDir: 'src/',
+  modules: ['@nuxt/content', '@nuxtjs/i18n'],
+  nitro: {
+    compatibilityDate: '2025-08-25'
+  }
 })

--- a/projects/AKSEP/package.json
+++ b/projects/AKSEP/package.json
@@ -5,7 +5,8 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "lint": "eslint .",
-    "start": "nuxt start"
+    "start": "nuxt start",
+    "test": "NUXT_TELEMETRY_DISABLED=1 vitest run"
   },
   "dependencies": {
     "@nuxt/content": "^2.8.0",
@@ -15,6 +16,8 @@
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@tsconfig/nuxt": "^2.0.3",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0",
+    "@nuxt/test-utils": "^3.19.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/projects/AKSEP/test/index.test.ts
+++ b/projects/AKSEP/test/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+await setup({ server: true })
+
+describe('index page', () => {
+  it('renders without Nuxt welcome', async () => {
+    const html = await $fetch('/')
+    expect(html).not.toContain('Welcome to Nuxt!')
+  })
+})


### PR DESCRIPTION
## Summary
- fix nuxt and i18n config imports and define source directory
- add basic vitest setup checking index page renders without Nuxt welcome
- document remaining TODO tasks for developers

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac59e94ac4833384185e1f4e09a966