### PR TITLE
[AKSEP]: configure Nuxt project and add basic test

### DIFF
--- a/projects/AKSEP/docs/TO-DO.md
+++ b/projects/AKSEP/docs/TO-DO.md
@@ -1,0 +1,6 @@
+# Offene Aufgaben
+
+- `.env` Datei basierend auf `.env.example` anlegen.
+- Komponenten `AppHeader` und `AppFooter` mit Inhalt füllen.
+- Weiterleitung von `src/pages/index.vue` zur eigentlichen Startseite implementieren.
+- Übersetzungsdateien `src/locales/*.json` mit Inhalten ergänzen.

--- a/projects/AKSEP/nuxt.config.ts
+++ b/projects/AKSEP/nuxt.config.ts
@@ -1,3 +1,7 @@
 export default defineNuxtConfig({
-  modules: ['@nuxt/content', '@nuxtjs/i18n']
+  srcDir: 'src',
+  modules: ['@nuxt/content', '@nuxtjs/i18n'],
+  nitro: {
+    compatibilityDate: '2025-08-25'
+  }
 })

--- a/projects/AKSEP/package.json
+++ b/projects/AKSEP/package.json
@@ -5,6 +5,7 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "lint": "eslint .",
+    "test": "vitest run",
     "start": "nuxt start"
   },
   "dependencies": {
@@ -15,6 +16,8 @@
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@tsconfig/nuxt": "^2.0.3",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0",
+    "@nuxt/test-utils": "3.18.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/projects/AKSEP/test/basic.test.ts
+++ b/projects/AKSEP/test/basic.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+await setup({ server: true })
+
+describe('index page', () => {
+  it('renders html', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('<div')
+    expect(html).not.toContain('Welcome to Nuxt')
+  })
+})

--- a/projects/AKSEP/tsconfig.json
+++ b/projects/AKSEP/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/nuxt/tsconfig.json",
   "compilerOptions": {
-    "types": ["@types/node"]
+    "types": ["@types/node", "nuxt", "@nuxtjs/i18n"]
   }
 }


### PR DESCRIPTION
## Summary
- set srcDir and nitro compatibility date to remove default welcome page
- fix TypeScript globals for Nuxt and i18n
- add vitest-based smoke test and developer TODOs

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac59e94ac4833384185e1f4e09a966