### PR TITLE
[AKSEP]: fix nuxt setup

### DIFF
--- a/projects/AKSEP/docs/TO-DO.md
+++ b/projects/AKSEP/docs/TO-DO.md
@@ -1,0 +1,5 @@
+# To-Do
+
+- Übersetzungsdateien in `src/locales` mit Inhalten füllen.
+- `src/app.config.ts` erweitern, um projektweite Einstellungen zu definieren.
+- Weitere Tests ergänzen, die den Seitenaufbau und die Vorschau abdecken.

--- a/projects/AKSEP/nuxt.config.ts
+++ b/projects/AKSEP/nuxt.config.ts
@@ -1,3 +1,14 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
 export default defineNuxtConfig({
-  modules: ['@nuxt/content', '@nuxtjs/i18n']
+  modules: ['@nuxt/content', '@nuxtjs/i18n'],
+  srcDir: 'src',
+  nitro: {
+    compatibilityDate: '2025-08-25'
+  },
+  i18n: {
+    vueI18n: './i18n.config.ts',
+    locales: ['de', 'en'],
+    defaultLocale: 'de'
+  }
 })

--- a/projects/AKSEP/package.json
+++ b/projects/AKSEP/package.json
@@ -5,6 +5,7 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "lint": "eslint .",
+    "test": "vitest run",
     "start": "nuxt start"
   },
   "dependencies": {
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@tsconfig/nuxt": "^2.0.3",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/projects/AKSEP/tests/nuxt-config.test.ts
+++ b/projects/AKSEP/tests/nuxt-config.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import config from '../nuxt.config'
+
+describe('nuxt configuration', () => {
+  it('uses src directory', () => {
+    expect(config.srcDir).toBe('src')
+  })
+})

--- a/projects/AKSEP/tsconfig.json
+++ b/projects/AKSEP/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/nuxt/tsconfig.json",
   "compilerOptions": {
-    "types": ["@types/node"]
+    "types": ["@types/node", "nuxt", "@nuxtjs/i18n"]
   }
 }


### PR DESCRIPTION
## Summary
- configure Nuxt to use `src` directory and add Nitro compatibility date
- expose Nuxt and i18n types to TypeScript and add basic test harness
- note remaining project tasks in docs/TO-DO

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac59e94ac4833384185e1f4e09a966